### PR TITLE
Display chosen sidebar item

### DIFF
--- a/src/Components/Sidebar/index.js
+++ b/src/Components/Sidebar/index.js
@@ -3,19 +3,15 @@ import React from "react";
 export default class Sidebar extends React.Component {
   renderChildren(children) {
     return Object.entries(children).map(([key, value]) => (
-      <li key={key} data-test="sidebar-item-child">
-        <a data-test="sidebar-item-child-link" href={value.link}>
-          {value.title}
-        </a>
+      <li key={key} data-test="sidebar-item-child">x
+        <button onClick={(_)=>this.props.updateParentForm(value.subSection)}  data-test="sidebar-item-child-button">{value.title}</button>
       </li>
     ));
   }
   renderItems() {
     return Object.entries(this.props.items).map(([key, value]) => (
       <li data-test="sidebar-item" key={key}>
-        <a data-test="sidebar-item-link" href={value.link}>
-          {value.title}
-        </a>
+        <button onClick={(_)=>this.props.updateParentForm(value.subSection)} data-test="sidebar-item-button">{value.title}</button>
         <ul data-test="sidebar-item-children">
           {value.children && this.renderChildren(value.children)}
         </ul>

--- a/src/Components/Sidebar/sidebar.test.js
+++ b/src/Components/Sidebar/sidebar.test.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Sidebar from ".";
 import { mount } from "enzyme";
+import {shallow} from "enzyme/build/index";
 
 describe("<Sidebar>", () => {
   let sidebar;
@@ -26,9 +27,11 @@ describe("<Sidebar>", () => {
   });
 
   describe("Given a single item with no children", () => {
+    let updateParentFormSpy = jest.fn();
+
     beforeEach(() => {
       sidebar = mount(
-        <Sidebar items={{ cats: { title: "Cats", link: "catLink" } }} />
+        <Sidebar items={{ cats: { title: "Cats", subSection: "aSubSectionAllAboutCats" } }} updateParentForm = {updateParentFormSpy}/>
       );
     });
 
@@ -44,23 +47,33 @@ describe("<Sidebar>", () => {
       ).toEqual("Cats");
     });
 
-    it("Sets the item href to the link", () => {
-      let link = sidebarItems()
+    it("Creates a button with an onClick function assigned", () => {
+      let button = sidebarItems()
         .at(0)
-        .find('[data-test="sidebar-item-link"]');
-
-      expect(link.props().href).toEqual("catLink");
+        .find('[data-test="sidebar-item-button"]');
+      expect(button.props().onClick).not.toBeNull();
     });
+
+    it("Calls updateParentForm method with subsection",()=>{
+      let button = sidebarItems()
+        .at(0)
+        .find('[data-test="sidebar-item-button"]');
+      button.simulate("click");
+      expect(updateParentFormSpy).toHaveBeenCalledWith("aSubSectionAllAboutCats");
+    })
   });
 
   describe("Given two items with no children", () => {
+    let updateParentFormSpy = jest.fn();
+
     beforeEach(() => {
       sidebar = mount(
         <Sidebar
           items={{
-            cows: { title: "Cows", link: "cowLink" },
-            dogs: { title: "Dogs", link: "dogLink" }
+            cows: { title: "Cows", subSection: "aSubSectionAllAboutCats" },
+            dogs: { title: "Dogs", subSection: "aSubSectionAllAboutDogs" }
           }}
+          updateParentForm = {updateParentFormSpy}
         />
       );
     });
@@ -75,49 +88,80 @@ describe("<Sidebar>", () => {
       expect(items.at(1).text()).toEqual("Dogs");
     });
 
-    it("Sets the item hrefs to the link", () => {
-      let linkOne = sidebarItems()
+    it("Creates two buttons with an onClick function assigned", () => {
+      let buttonOne = sidebarItems()
         .at(0)
-        .find('[data-test="sidebar-item-link"]');
-
-      let linkTwo = sidebarItems()
+        .find('[data-test="sidebar-item-button"]');
+      expect(buttonOne.props().onClick).not.toBeNull();
+      let buttonTwo = sidebarItems()
         .at(1)
-        .find('[data-test="sidebar-item-link"]');
+        .find('[data-test="sidebar-item-button"]');
+      expect(buttonTwo.props().onClick).not.toBeNull();
 
-      expect(linkOne.props().href).toEqual("cowLink");
-      expect(linkTwo.props().href).toEqual("dogLink");
     });
+
+    it("Calls updateParentForm method with subsection",()=>{
+      let buttonOne = sidebarItems()
+        .at(0)
+        .find('[data-test="sidebar-item-button"]');
+      let buttonTwo = sidebarItems()
+        .at(1)
+        .find('[data-test="sidebar-item-button"]');
+
+
+      buttonOne.simulate("click");
+      expect(updateParentFormSpy).toHaveBeenCalledWith("aSubSectionAllAboutCats");
+
+      buttonTwo.simulate("click");
+      expect(updateParentFormSpy).toHaveBeenCalledWith("aSubSectionAllAboutDogs");
+    })
   });
 
   describe("Given one item with a child", () => {
+    let updateParentFormSpy = jest.fn();
+
     beforeEach(() => {
       sidebar = mount(
         <Sidebar
           items={{
             cows: {
               title: "Cows",
-              children: { noises: { title: "noises", link: "noisesLink" } }
+              children: { noises: { title: "noises", subSection: "aSubSectionAllAboutNoises" } }
             }
           }}
+          updateParentForm = {updateParentFormSpy}
         />
       );
     });
     it("An item and its child", () => {
       expect(sidebarItems().length).toEqual(1);
     });
+    
+    it("Creates a button with an onClick function assigned", () => {
+      let button = sidebarItems()
+        .at(0)
+        .find('[data-test="sidebar-item-child-button"]');
+      expect(button.props().onClick).not.toBeNull();
+    });
 
     it("sets the child title to the title given", () => {
-      let link = sidebar.find('[data-test="sidebar-item-child-link"]');
+      let link = sidebar.find('[data-test="sidebar-item-child-button"]');
       expect(link.text()).toEqual("noises");
     });
 
-    it("sets the child href to the link given", () => {
-      let link = sidebar.find('[data-test="sidebar-item-child-link"]');
-      expect(link.props().href).toEqual("noisesLink");
-    });
+    it("Calls updateParentForm method with subsection",()=>{
+      let button = sidebarItems()
+        .at(0)
+        .find('[data-test="sidebar-item-child-button"]');
+      button.simulate("click");
+      expect(updateParentFormSpy).toHaveBeenCalledWith("aSubSectionAllAboutNoises");
+    })
+
   });
 
   describe("Given one item with two children", () => {
+    let updateParentFormSpy = jest.fn();
+
     beforeEach(() => {
       sidebar = mount(
         <Sidebar
@@ -125,11 +169,12 @@ describe("<Sidebar>", () => {
             cows: {
               title: "Cows",
               children: {
-                noises: { title: "noises", link: "noisesLink" },
-                likes: { title: "people", link: "peopleLink" }
+                noises: { title: "noises", subSection: "aSubSectionAllAboutNoises" },
+                likes: { title: "people", subSection: "aSubSectionAboutHorriblePeople" }
               }
             }
           }}
+          updateParentForm = {updateParentFormSpy}
         />
       );
     });
@@ -137,22 +182,34 @@ describe("<Sidebar>", () => {
       expect(sidebarItemChildren(0).length).toEqual(2);
     });
 
-    it("sets the children titles to the title given", () => {
-      let links = sidebar.find('[data-test="sidebar-item-child-link"]');
-
-      expect(links.at(0).text()).toEqual("noises");
-      expect(links.at(1).text()).toEqual("people");
+    it("Creates two buttons with an onClick function assigned", () => {
+      let buttons = sidebar.find('[data-test="sidebar-item-child-button"]');
+      expect(buttons.at(0).props().onClick).not.toBeNull();
+      expect(buttons.at(1).props().onClick).not.toBeNull();
     });
 
-    it("sets the children titles to the title given", () => {
-      let links = sidebar.find('[data-test="sidebar-item-child-link"]');
 
-      expect(links.at(0).props().href).toEqual("noisesLink");
-      expect(links.at(1).props().href).toEqual("peopleLink");
+    it("sets the children titles to the title given", () => {
+      let buttons = sidebar.find('[data-test="sidebar-item-child-button"]');
+
+      expect(buttons.at(0).text()).toEqual("noises");
+      expect(buttons.at(1).text()).toEqual("people");
     });
+
+    it("Calls updateParentForm method with subsection",()=>{
+      let buttons = sidebar.find('[data-test="sidebar-item-child-button"]');
+      buttons.at(0).simulate("click");
+      expect(updateParentFormSpy).toHaveBeenCalledWith("aSubSectionAllAboutNoises");
+
+      buttons.at(1).simulate("click");
+      expect(updateParentFormSpy).toHaveBeenCalledWith("aSubSectionAboutHorriblePeople");
+    })
+
   });
 
   describe("Given two items with children", () => {
+    let updateParentFormSpy = jest.fn();
+
     beforeEach(() => {
       sidebar = mount(
         <Sidebar
@@ -160,15 +217,16 @@ describe("<Sidebar>", () => {
             cows: {
               title: "Cows",
               children: {
-                noises: { title: "noises", link: "linkToDaNoise" },
-                likes: { title: "people", link: "peopleLink" }
+                noises: { title: "noises", subSection: "aSubSectionAllAboutNoises" },
+                likes: { title: "people", subSection: "aSubSectionAboutHorriblePeople" }
               }
             },
             dogs: {
               title: "Dogs",
-              children: { toys: { title: "Toys", link: "dogToys4U.bark" } }
+              children: { toys: { title: "Toys", subSection: "aSubSectionAboutToys4U.bark" } }
             }
           }}
+          updateParentForm = {updateParentFormSpy}
         />
       );
     });
@@ -181,32 +239,53 @@ describe("<Sidebar>", () => {
       expect(itemTwoChildren.length).toEqual(1);
     });
 
-    it("sets the children titles to the title given", () => {
-      let itemOneChildrenLinks = sidebarItems()
+    it("Creates two buttons with an onClick function assigned", () => {
+      let itemOneChildrenButtons = sidebarItems()
         .at(0)
-        .find('[data-test="sidebar-item-child-link"]');
+        .find('[data-test="sidebar-item-child-button"]');
 
-      let itemTwoChildrenLinks = sidebarItems()
+      let itemTwoChildrenButtons = sidebarItems()
         .at(1)
-        .find('[data-test="sidebar-item-child-link"]');
+        .find('[data-test="sidebar-item-child-button"]');
 
-      expect(itemOneChildrenLinks.at(0).text()).toEqual("noises");
-      expect(itemOneChildrenLinks.at(1).text()).toEqual("people");
-      expect(itemTwoChildrenLinks.at(0).text()).toEqual("Toys");
+      expect(itemOneChildrenButtons.at(0).props().onClick).not.toBeNull();
+      expect(itemOneChildrenButtons.at(1).props().onClick).not.toBeNull();
+      expect(itemTwoChildrenButtons.at(0).props().onClick).not.toBeNull();
+
     });
 
     it("sets the children titles to the title given", () => {
-      let itemOneChildrenLinks = sidebarItems()
+      let itemOneChildrenButtons = sidebarItems()
         .at(0)
-        .find('[data-test="sidebar-item-child-link"]');
+        .find('[data-test="sidebar-item-child-button"]');
 
-      let itemTwoChildrenLinks = sidebarItems()
+      let itemTwoChildrenButtons = sidebarItems()
         .at(1)
-        .find('[data-test="sidebar-item-child-link"]');
+        .find('[data-test="sidebar-item-child-button"]');
 
-      expect(itemOneChildrenLinks.at(0).props().href).toEqual("linkToDaNoise");
-      expect(itemOneChildrenLinks.at(1).props().href).toEqual("peopleLink");
-      expect(itemTwoChildrenLinks.at(0).props().href).toEqual("dogToys4U.bark");
+      expect(itemOneChildrenButtons.at(0).text()).toEqual("noises");
+      expect(itemOneChildrenButtons.at(1).text()).toEqual("people");
+      expect(itemTwoChildrenButtons.at(0).text()).toEqual("Toys");
     });
+
+    it("Calls updateParentForm method with subsection",()=>{
+      let itemOneChildrenButtons = sidebarItems()
+        .at(0)
+        .find('[data-test="sidebar-item-child-button"]');
+
+
+      let itemTwoChildrenButtons = sidebarItems()
+        .at(1)
+        .find('[data-test="sidebar-item-child-button"]');
+
+      itemOneChildrenButtons.at(0).simulate("click");
+      expect(updateParentFormSpy).toHaveBeenCalledWith("aSubSectionAllAboutNoises");
+
+      itemOneChildrenButtons.at(1).simulate("click");
+      expect(updateParentFormSpy).toHaveBeenCalledWith("aSubSectionAboutHorriblePeople");
+
+      itemTwoChildrenButtons.at(0).simulate("click");
+      expect(updateParentFormSpy).toHaveBeenCalledWith("aSubSectionAboutToys4U.bark");
+    })
   });
 });


### PR DESCRIPTION
**WIP**

WHAT 
The Sidebar should not longer link to sections within the Return but should get ParentForm to display the subsection.

WHY 
To reduce visual noise only parts of the Return are to be displayed. 