### PR TITLE
Add module for runtime environment variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -167,6 +167,11 @@
         }
       }
     },
+    "@mars/heroku-js-runtime-env": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@mars/heroku-js-runtime-env/-/heroku-js-runtime-env-3.0.2.tgz",
+      "integrity": "sha1-5bhIDtgrVARkdKCKE5uNlWCvOig="
+    },
     "@storybook/addon-actions": {
       "version": "3.4.8",
       "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.4.8.tgz",
@@ -6105,7 +6110,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6123,11 +6129,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6140,15 +6148,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6251,7 +6262,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6261,6 +6273,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6273,17 +6286,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6300,6 +6316,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6372,7 +6389,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6382,6 +6400,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6457,7 +6476,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6487,6 +6507,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6504,6 +6525,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6542,11 +6564,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@mars/heroku-js-runtime-env": "^3.0.2",
     "cors": "^2.8.4",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",

--- a/src/Gateway/ProjectGateway/index.js
+++ b/src/Gateway/ProjectGateway/index.js
@@ -1,10 +1,12 @@
 import Project from '../../Domain/Project'
 import fetch from 'isomorphic-fetch'
+import runtimeEnv from '@mars/heroku-js-runtime-env';
 
 export default class ProjectGateway {
   async findById(id) {
+    let env = runtimeEnv()
     let rawResponse = await fetch(
-      `${process.env.REACT_APP_HIF_API_URL}project/find?id=${id}`,
+      `${env.REACT_APP_HIF_API_URL}project/find?id=${id}`,
       {
         headers: {'Content-Type': 'application/json',
           'API_KEY': window.apiKey},

--- a/src/Gateway/ReturnGateway/index.js
+++ b/src/Gateway/ReturnGateway/index.js
@@ -1,10 +1,15 @@
 import fetch from 'isomorphic-fetch';
 import Return from '../../Domain/Return';
+import runtimeEnv from '@mars/heroku-js-runtime-env';
 
 export default class ReturnGateway {
+  constructor() {
+    this.env = runtimeEnv()
+  }
+
   async baseReturnFor(id) {
     let rawResponse = await fetch(
-      `${process.env.REACT_APP_HIF_API_URL}project/${id}/return`,
+      `${this.env.REACT_APP_HIF_API_URL}project/${id}/return`,
       {
         headers: {'Content-Type': 'application/json',
           'API_KEY': window.apiKey},
@@ -22,7 +27,7 @@ export default class ReturnGateway {
 
   async findById(id) {
     let rawResponse = await fetch(
-      `${process.env.REACT_APP_HIF_API_URL}return/get?id=${id}`,
+      `${this.env.REACT_APP_HIF_API_URL}return/get?id=${id}`,
       {
         headers: {'Content-Type': 'application/json',
           'API_KEY': window.apiKey},
@@ -38,7 +43,7 @@ export default class ReturnGateway {
 
   async create(id, data) {
     let rawResponse = await fetch(
-      `${process.env.REACT_APP_HIF_API_URL}return/create`,
+      `${this.env.REACT_APP_HIF_API_URL}return/create`,
       {
         method: 'POST',
         headers: {'Content-Type': 'application/json',
@@ -57,7 +62,7 @@ export default class ReturnGateway {
 
   async update(return_id, return_data) {
     let response = await fetch(
-      `${process.env.REACT_APP_HIF_API_URL}return/update`,
+      `${this.env.REACT_APP_HIF_API_URL}return/update`,
       {
         method: 'POST',
         headers: {'Content-Type': 'application/json',
@@ -75,7 +80,7 @@ export default class ReturnGateway {
 
   async submit(return_id, data) {
     let response = await fetch(
-      `${process.env.REACT_APP_HIF_API_URL}return/submit`,
+      `${this.env.REACT_APP_HIF_API_URL}return/submit`,
       {
         method: 'POST',
         headers: {'Content-Type': 'application/json',

--- a/src/Gateway/TokenGateway/index.js
+++ b/src/Gateway/TokenGateway/index.js
@@ -1,10 +1,14 @@
 import fetch from 'isomorphic-fetch';
 import ApiKey from '../../Domain/ApiKey';
+import runtimeEnv from '@mars/heroku-js-runtime-env'
 
 export default class TokenGateway {
+  constructor() {
+    this.env = runtimeEnv()
+  }
   async requestToken(email_address, url) {
     let response = await fetch(
-      `${process.env.REACT_APP_HIF_API_URL}token/request`,
+      `${this.env.REACT_APP_HIF_API_URL}token/request`,
       {
         method: 'POST',
         headers: {'Content-Type': 'application/json',
@@ -16,7 +20,7 @@ export default class TokenGateway {
 
   async getApiKey(access_token) {
     let response = await fetch(
-      `${process.env.REACT_APP_HIF_API_URL}token/expend`,
+      `${this.env.REACT_APP_HIF_API_URL}token/expend`,
       {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},


### PR DESCRIPTION
Due to heroku promtion not causing a rebuild, to speed up deploys from
staging to prod, we now use a package for getting runtime env variables
in built applications

https://github.com/mars/create-react-app-buildpack/blob/master/README.md#runtime-configuration