### PR TITLE
Require login on all routes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -41,14 +41,3 @@ html {
   background-color: #FFE644;
   color: black;
 }
-
-input {
-  width: 100%;
-  padding: 12px 20px;
-  margin: 8px 0;
-  box-sizing: border-box;
-}
-
-button {
-  float: right;
-}

--- a/src/App.js
+++ b/src/App.js
@@ -1,32 +1,32 @@
-import React from 'react';
-import qs from 'qs';
+import React from "react";
+import qs from "qs";
 
-import Footer from './Components/Footer';
-import Header from './Components/Header';
-import ProjectForm from './Components/ProjectForm';
-import ProjectPage from './Components/ProjectPage';
-import ReturnPage from './Components/ReturnPage';
-import GetToken from './Components/GetToken'
-import Portal from './Components/Portal';
+import Footer from "./Components/Footer";
+import Header from "./Components/Header";
+import ProjectForm from "./Components/ProjectForm";
+import ProjectPage from "./Components/ProjectPage";
+import ReturnPage from "./Components/ReturnPage";
+import GetToken from "./Components/GetToken";
+import Portal from "./Components/Portal";
 
-import CreateReturn from './UseCase/CreateReturn';
-import GenerateDisabledUISchema from './UseCase/GenerateDisabledUISchema'
-import GenerateReadOnlySchema from './UseCase/GenerateReadOnlySchema'
-import GenerateUISchema from './UseCase/GenerateUISchema'
-import GetBaseReturn from './UseCase/GetBaseReturn';
-import CanAccessProject from './UseCase/CanAccessProject';
-import GetProject from './UseCase/GetProject';
-import GetReturn from './UseCase/GetReturn';
-import SubmitReturn from './UseCase/SubmitReturn';
-import UpdateReturn from './UseCase/UpdateReturn';
-import RequestToken from './UseCase/RequestToken'
+import CreateReturn from "./UseCase/CreateReturn";
+import GenerateDisabledUISchema from "./UseCase/GenerateDisabledUISchema";
+import GenerateReadOnlySchema from "./UseCase/GenerateReadOnlySchema";
+import GenerateUISchema from "./UseCase/GenerateUISchema";
+import GetBaseReturn from "./UseCase/GetBaseReturn";
+import CanAccessProject from "./UseCase/CanAccessProject";
+import GetProject from "./UseCase/GetProject";
+import GetReturn from "./UseCase/GetReturn";
+import SubmitReturn from "./UseCase/SubmitReturn";
+import UpdateReturn from "./UseCase/UpdateReturn";
+import RequestToken from "./UseCase/RequestToken";
 
-import ProjectGateway from './Gateway/ProjectGateway';
-import ReturnGateway from './Gateway/ReturnGateway';
-import TokenGateway from './Gateway/TokenGateway'
+import ProjectGateway from "./Gateway/ProjectGateway";
+import ReturnGateway from "./Gateway/ReturnGateway";
+import TokenGateway from "./Gateway/TokenGateway";
 
-import './App.css';
-import {BrowserRouter as Router, Route} from 'react-router-dom';
+import "./App.css";
+import { BrowserRouter as Router, Route } from "react-router-dom";
 
 const createReturnUseCase = new CreateReturn(new ReturnGateway());
 const generateDisabledUISchema = new GenerateDisabledUISchema();
@@ -40,6 +40,27 @@ const requestTokenUseCase = new RequestToken(new TokenGateway());
 const submitReturnUseCase = new SubmitReturn(new ReturnGateway());
 const updateReturnUseCase = new UpdateReturn(new ReturnGateway());
 
+const renderReturnPage = props => (
+  <ReturnPage
+    {...props}
+    getReturn={getReturnUseCase}
+    getBaseReturn={getBaseReturnUseCase}
+    createReturn={createReturnUseCase}
+    submitReturn={submitReturnUseCase}
+    updateReturn={updateReturnUseCase}
+    generateUISchema={generateUISchema}
+    generateSubmittedSchema={generateDisabledUISchema}
+  />
+);
+
+const renderProjectPage = props => (
+  <ProjectPage
+    {...props}
+    getProject={getProjectUseCase}
+    generateUISchema={generateDisabledUISchema}
+  />
+);
+
 const App = () => (
   <Router>
     <div className="app-container">
@@ -48,54 +69,33 @@ const App = () => (
       <div className="monitor-container">
         <Route exact path="/" component={Home} />
         <Route
-          exact
           path="/project/:id"
-          render={ props =>
+          render={props => (
             <Portal
               {...props}
               projectId={props.match.params.id}
-              onApiKey={(apiKey) => {window.apiKey = apiKey}}
+              onApiKey={apiKey => {
+                window.apiKey = apiKey;
+              }}
               requestToken={requestTokenUseCase}
-              token={qs.parse(props.location.search, { ignoreQueryPrefix: true }).token}
+              token={
+                qs.parse(props.location.search, { ignoreQueryPrefix: true })
+                  .token
+              }
               canAccessProject={canAccessProjectUseCase}
-            ><ProjectPage
-                {...props}
-                getProject={getProjectUseCase}
-                generateUISchema={generateDisabledUISchema}
+            >
+              <Route exact path="/project/:id" render={renderProjectPage} />
+              <Route
+                exact
+                path="/project/:projectId/return"
+                render={renderReturnPage}
               />
-              </Portal>
-          }
-        />
-        <Route
-          exact
-          path="/project/:projectId/return"
-          render={props => (
-            <ReturnPage
-              {...props}
-              getReturn={getReturnUseCase}
-              getBaseReturn={getBaseReturnUseCase}
-              createReturn={createReturnUseCase}
-              submitReturn={submitReturnUseCase}
-              updateReturn={updateReturnUseCase}
-              generateUISchema={generateUISchema}
-              generateSubmittedSchema={generateDisabledUISchema}
-            />
-          )}
-        />
-        <Route
-          exact
-          path="/project/:projectId/return/:returnId"
-          render={props => (
-            <ReturnPage
-              {...props}
-              getReturn={getReturnUseCase}
-              createReturn={createReturnUseCase}
-              getBaseReturn={getBaseReturnUseCase}
-              submitReturn={submitReturnUseCase}
-              updateReturn={updateReturnUseCase}
-              generateUISchema={generateUISchema}
-              generateSubmittedSchema={generateDisabledUISchema}
-            />
+              <Route
+                exact
+                path="/project/:projectId/return/:returnId"
+                render={renderReturnPage}
+              />
+            </Portal>
           )}
         />
       </div>

--- a/src/App.js
+++ b/src/App.js
@@ -55,16 +55,15 @@ const App = () => (
               {...props}
               projectId={props.match.params.id}
               onApiKey={(apiKey) => {window.apiKey = apiKey}}
-              target={<ProjectPage
-                {...props}
-                getProject={getProjectUseCase}
-                generateUISchema={generateDisabledUISchema}
-              />}
-
               requestToken={requestTokenUseCase}
               token={qs.parse(props.location.search, { ignoreQueryPrefix: true }).token}
               canAccessProject={canAccessProjectUseCase}
-            />
+            ><ProjectPage
+                {...props}
+                getProject={getProjectUseCase}
+                generateUISchema={generateDisabledUISchema}
+              />
+              </Portal>
           }
         />
         <Route

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -51,6 +51,41 @@ let returnData = {
   }
 };
 
+describe("Authentication against routes", () => {
+  let api;
+
+  beforeEach(() => {
+    process.env.REACT_APP_HIF_API_URL = "http://cat.meow/";
+    api = new APISimulator("http://cat.meow");
+    api.expendEmptyTokenForProject(0).unauthorised();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it("Asks for authentication against the project page", async () => {
+    let page = new AppPage("/project/0");
+    await page.load();
+
+    expect(page.find("GetToken").length).toEqual(1);
+  });
+
+  it("Asks for authentication against the base return page", async () => {
+    let page = new AppPage("/project/0/return");
+    await page.load();
+
+    expect(page.find("GetToken").length).toEqual(1);
+  });
+
+  it("Asks for authentication against the view return page", async () => {
+    let page = new AppPage("/project/0/return/1");
+    await page.load();
+
+    expect(page.find("GetToken").length).toEqual(1);
+  });
+});
+
 describe("Viewing at a project", () => {
   let api;
 
@@ -132,7 +167,12 @@ describe("Viewing at a project", () => {
       let page = new AppPage("/project/0/return/0?token=Cats");
       await page.load();
 
-      let expectedInputValues = ["Meow", "Fluffy balls of friendship", "Beans", ""];
+      let expectedInputValues = [
+        "Meow",
+        "Fluffy balls of friendship",
+        "Beans",
+        ""
+      ];
       expect(page.getFormInputs()).toEqual(expectedInputValues);
     });
   });

--- a/src/Components/GetToken/index.js
+++ b/src/Components/GetToken/index.js
@@ -1,39 +1,73 @@
-import fetch from 'isomorphic-fetch';
+import fetch from "isomorphic-fetch";
 
-import React from 'react';
-import './style.css'
+import React from "react";
+import "./style.css";
 
 export default class GetToken extends React.Component {
   constructor(props) {
-    super(props)
+    super(props);
     this.state = {
-      email: '',
+      email: "",
       message_sent: false
-    }
+    };
   }
 
-  emailChange = (e) => {
-    this.setState({email: e.target.value});
-  }
+  emailChange = e => {
+    this.setState({ email: e.target.value });
+  };
 
-  sendRequest = (e) => {
-    this.props.requestToken.execute(this.state.email, this.props.projectId, this.props.targetUrl)
-    this.setState({message_sent: true})
+  sendRequest = e => {
+    this.props.requestToken.execute(
+      this.state.email,
+      this.props.projectId,
+      this.props.targetUrl
+    );
+    this.setState({ message_sent: true });
     e.preventDefault();
-  }
+  };
+
+  renderMessageSent = () => {
+    return (
+      <div data-test="sent_message">
+        <h3>We&#39;ve sent an email to {this.state.email}</h3>
+        <p>
+          Didn&#39;t receive an email? Check your spam and make sure you entered
+          your email correctly.
+        </p>
+      </div>
+    );
+  };
 
   render() {
     if (this.state.message_sent) {
-      return (<div data-test="sent_message">
-        <h3>We&#39;ve sent an email to {this.state.email}</h3>
-        <p>Didn&#39;t receive an email? Check your spam and make sure you entered your email correctly.</p>
-        </div>)
+      return this.renderMessageSent();
     } else {
-      return (<form onSubmit={this.sendRequest}>
-        {"You do not have permission to view this page, please enter your email:"} <br/>
-        <input data-test="email_input" type="text" onChange={this.emailChange}></input>
-        <input data-test="submit_button" type="submit" value="Request Access"/>
-      </form>)
+      return (
+        <div className="col-md-offset-4 col-md-4">
+          <h4>
+            You do not have permission to view this page, please enter your
+            email:
+          </h4>
+          <form onSubmit={this.sendRequest}>
+            <div className="form-group">
+              <input
+                data-test="email_input"
+                type="text"
+                className="form-control"
+                placeholder="email@example.com"
+                onChange={this.emailChange}
+              />
+            </div>
+            <button
+              data-test="submit_button"
+              type="submit"
+              className="btn btn-primary"
+            >
+              Request Access
+            </button>
+          </form>
+        </div>
+      );
     }
   }
 }

--- a/src/Components/GetToken/stories.js
+++ b/src/Components/GetToken/stories.js
@@ -3,5 +3,14 @@ import GetToken from ".";
 import { storiesOf } from "@storybook/react";
 
 storiesOf("GetToken", module).add("Default", () => {
-  return <GetToken targetUrl="#" requestToken={{execute: () => {console.log("token requested")}}}/>;
+  return (
+    <GetToken
+      targetUrl="#"
+      requestToken={{
+        execute: () => {
+          console.log("token requested");
+        }
+      }}
+    />
+  );
 });

--- a/src/Components/Portal/index.js
+++ b/src/Components/Portal/index.js
@@ -22,7 +22,7 @@ export default class Portal extends React.Component {
         if (this.props.onApiKey) {
           this.props.onApiKey(this.state.apiKey.apiKey)
         }
-        return this.props.target
+        return this.props.children
       } else {
         return <GetToken projectId={this.props.projectId} targetUrl={window.location.href} requestToken={this.props.requestToken}/>
       }

--- a/src/Components/Portal/index.js
+++ b/src/Components/Portal/index.js
@@ -8,6 +8,7 @@ export default class Portal extends React.Component {
       apiKey: null
     }
   }
+
   componentDidMount() {
     this.props.canAccessProject.execute(this.props.token, parseInt(this.props.projectId)).then(apiKey => this.setState({apiKey}))
   }

--- a/src/Components/Portal/index.js
+++ b/src/Components/Portal/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import Form from 'react-jsonschema-form';
 import GetToken from '../GetToken'
 
 export default class Portal extends React.Component {

--- a/src/Components/Portal/portal.test.js
+++ b/src/Components/Portal/portal.test.js
@@ -1,102 +1,141 @@
-import React from 'react';
-import Portal from '.';
-import {mount} from 'enzyme';
+import React from "react";
+import Portal from ".";
+import { mount } from "enzyme";
 
 async function wait() {
   await new Promise(resolve => setTimeout(resolve, 100));
 }
 
 async function updateFormField(input, value) {
-  input.simulate('change', {target: {value}});
+  input.simulate("change", { target: { value } });
   await wait();
 }
 
-describe('Portal', () => {
+describe("Portal", () => {
   let CanAccessProjectSpy = {
     execute: jest.fn(async () => {
       return {
         valid: true,
-        apiKey: 'Dogs'
-      }
+        apiKey: "Dogs"
+      };
     })
-  }
+  };
 
   let RequestTokenSpy = {
     execute: jest.fn()
-  }
+  };
 
-  it('calls the CanAccessProject use case', async () => {
-    let wrapper = mount(<Portal projectId="1" target={<div/>} token="Cats" canAccessProject={CanAccessProjectSpy}/>)
+  it("calls the CanAccessProject use case", async () => {
+    let wrapper = mount(
+      <Portal projectId="1" token="Cats" canAccessProject={CanAccessProjectSpy}>
+        <div />
+      </Portal>
+    );
 
-    await wait()
-    expect(CanAccessProjectSpy.execute).toHaveBeenCalledWith("Cats", 1)
+    await wait();
+    expect(CanAccessProjectSpy.execute).toHaveBeenCalledWith("Cats", 1);
   });
 
-  it('calls the requestToken use case', async () => {
+  it("calls the requestToken use case", async () => {
     CanAccessProjectSpy = {
       execute: jest.fn(async () => {
         return {
           valid: false
-        }
+        };
       })
-    }
-    let wrapper = mount(<Portal projectId="1" target={<div/>} token="Cats" canAccessProject={CanAccessProjectSpy} requestToken={RequestTokenSpy}/>)
+    };
+    let wrapper = mount(
+      <Portal
+        projectId="1"
+        token="Cats"
+        canAccessProject={CanAccessProjectSpy}
+        requestToken={RequestTokenSpy}
+      >
+        <div />
+      </Portal>
+    );
 
-    await wait()
-    wrapper.update()
-    let email_entry = wrapper.find('[data-test="email_input"]')
-    await updateFormField(email_entry,'cats@cathouse.com')
+    await wait();
+    wrapper.update();
+    let email_entry = wrapper.find('[data-test="email_input"]');
+    await updateFormField(email_entry, "cats@cathouse.com");
 
-    let submit_button = wrapper.find('form')
-    submit_button.simulate('submit');
+    let submit_button = wrapper.find("form");
+    submit_button.simulate("submit");
 
-    await wait()
-    wrapper.update()
+    await wait();
+    wrapper.update();
 
-    expect(RequestTokenSpy.execute).toHaveBeenCalledWith("cats@cathouse.com", "1", "http://localhost/")
+    expect(RequestTokenSpy.execute).toHaveBeenCalledWith(
+      "cats@cathouse.com",
+      "1",
+      "http://localhost/"
+    );
   });
 
-  it('calls the onApiKey callback', async () => {
-    CanAccessProjectSpy = {
-      execute: jest.fn(async () => {
-        return {
-          valid: true, apiKey: "Dogs"
-        }
-      })
-    }
-    let OnApiKey = jest.fn()
-    let wrapper = mount(<Portal projectId="1" target={<div/>} onApiKey={OnApiKey} token="Cats" canAccessProject={CanAccessProjectSpy} requestToken={RequestTokenSpy}/>)
-    await wait()
-    wrapper.update()
-    expect(OnApiKey).toHaveBeenCalledWith("Dogs")
-  });
-
-  it('shows getToken if use case returns false', async () => {
-    CanAccessProjectSpy = {
-      execute: jest.fn(async () => {
-        return {
-          valid: false
-        }
-      })
-    }
-    let wrapper = mount(<Portal projectId="1" target={<div/>} token="Cats" canAccessProject={CanAccessProjectSpy}/>)
-    await wait()
-    wrapper.update()
-    expect(wrapper.find('GetToken').length).toEqual(1)
-  });
-
-  it('does not show getToken if the use case returns true', async () => {
+  it("calls the onApiKey callback", async () => {
     CanAccessProjectSpy = {
       execute: jest.fn(async () => {
         return {
           valid: true,
-          apiKey: 'Cows'
-        }
+          apiKey: "Dogs"
+        };
       })
-    }
-    let wrapper = mount(<Portal projectId="1" target={<div/>} token="Cats" canAccessProject={CanAccessProjectSpy}/>)
-    await wait()
-    wrapper.update()
-    expect(wrapper.find('GetToken').length).toEqual(0)
+    };
+    let OnApiKey = jest.fn();
+    let wrapper = mount(
+      <Portal
+        projectId="1"
+        onApiKey={OnApiKey}
+        token="Cats"
+        canAccessProject={CanAccessProjectSpy}
+        requestToken={RequestTokenSpy}
+      >
+        <div />
+      </Portal>
+    );
+    await wait();
+    wrapper.update();
+    expect(OnApiKey).toHaveBeenCalledWith("Dogs");
   });
-})
+
+  it("shows getToken if use case returns false", async () => {
+    CanAccessProjectSpy = {
+      execute: jest.fn(async () => {
+        return {
+          valid: false
+        };
+      })
+    };
+    let wrapper = mount(
+      <Portal
+        projectId="1"
+        token="Cats"
+        canAccessProject={CanAccessProjectSpy}
+      />
+    );
+    await wait();
+    wrapper.update();
+    expect(wrapper.find("GetToken").length).toEqual(1);
+  });
+
+  it("renders chidlren if the use case returns true", async () => {
+    CanAccessProjectSpy = {
+      execute: jest.fn(async () => {
+        return {
+          valid: true,
+          apiKey: "Cows"
+        };
+      })
+    };
+
+    let wrapper = mount(
+      <Portal projectId="1" token="Cats" canAccessProject={CanAccessProjectSpy}>
+        <h1>Hiya!</h1>
+      </Portal>
+    );
+    await wait();
+    wrapper.update();
+    expect(wrapper.find("GetToken").length).toEqual(0);
+  });
+});

--- a/test/ApiSimulator/index.js
+++ b/test/ApiSimulator/index.js
@@ -29,6 +29,14 @@ class APISimulator {
     return new APIResponse(returnRequest, response);
   }
 
+  expendEmptyTokenForProject(project_id) {
+    let request = nock(this.url)
+      .matchHeader("Content-Type", "application/json")
+      .post("/token/expend", { project_id });
+
+    return new APIResponse(request, { apiKey: "abc" });
+  }
+
   expendToken(access_token, project_id) {
     let request = nock(this.url)
       .matchHeader("Content-Type", "application/json")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/976254/45152336-9e2b1800-b1c8-11e8-8561-a41ea9abcf54.png)

**WHAT**
- Changes the portal component to take children and render them
- Put the routes as children to the portal component

**WHY**
- This allows us to reuse the portal to wrap every route following `/project/:id`