### PR TITLE
Support 'addable' arrays in schema

### DIFF
--- a/src/UseCase/GenerateUISchema/generateUISchema.test.js
+++ b/src/UseCase/GenerateUISchema/generateUISchema.test.js
@@ -231,6 +231,41 @@ describe("GenerateUISchema", () => {
     });
   });
 
+  describe("Addable arrays", () => {
+    describe("Given an array that is addable", () => {
+      it("Marks them as addable", () => {
+        let useCase = new GenerateUISchema();
+        let schema = {
+          type: "object",
+          properties: {
+            a: {
+              type: "array",
+              addable: true,
+              items: {
+                type: "object",
+                properties: {
+                  b: { type: "string" },
+                  c: { type: "string" }
+                }
+              }
+            }
+          }
+        };
+        let response = useCase.execute(schema);
+        expect(response).toEqual({
+          a: {
+            "ui:options": {
+              addable: true,
+              orderable: false,
+              removable: true
+            },
+            items: {}
+          }
+        });
+      });
+    });
+  });
+
   describe("Horizontal", () => {
     describe("Given an object", () => {
       describe("That is horizontal", () => {

--- a/src/UseCase/GenerateUISchema/index.js
+++ b/src/UseCase/GenerateUISchema/index.js
@@ -16,9 +16,9 @@ export default class GenerateUISchema {
       } else if (value.type === "array") {
         ret[key] = {};
         ret[key]["ui:options"] = {
-          addable: false,
+          addable: this.isAddableArray(value),
           orderable: false,
-          removable: false
+          removable: this.isAddableArray(value)
         };
         ret[key]["items"] = this.generateUISchema(value.items.properties);
       } else if (value.readonly) {
@@ -26,5 +26,9 @@ export default class GenerateUISchema {
       }
     });
     return ret;
+  }
+
+  isAddableArray(arr) {
+    return arr.addable ? true : false;
   }
 }


### PR DESCRIPTION
What - Allows the ability to mark some arrays as `addable` in the schema

Why -  this is for places where the user may want to add an arbitrary number of entries e.g. New Risks