### PR TITLE
Improve return form UX

### DIFF
--- a/src/Components/ParentForm/index.js
+++ b/src/Components/ParentForm/index.js
@@ -57,7 +57,7 @@ export default class ParentForm extends React.Component {
       <li
         key={property}
         role="presentation"
-        className={property === this.state.selected ? "active" : "inactive"}
+        className={"nav-item " + (property === this.state.selected ? "active" : "inactive")}
       >
         <a role="button" id={property} onClick={this.viewSelectorOnChange}>
           {this.props.schema.properties[property].title}

--- a/src/Components/ParentForm/style.css
+++ b/src/Components/ParentForm/style.css
@@ -7,23 +7,33 @@
   border-bottom: none;
 }
 
-.nav-tabs > li {
+.nav-item {
+  border-bottom: 0px solid black;
   margin-bottom: -2px;
 }
 
-.nav-tabs > li > a {
+
+.nav-item.active > a {
+  border-color: #0e0e0e !important;
+  color: #005ea8 !important;
+  border-radius: 0;
+}
+
+.nav-item.inactive > a:hover {
+  border-color: #787878 !important;
+  border-radius: 0;
+}
+
+.nav-item > a {
+  border-bottom: transparent !important;
   color: #787878;
+  cursor: pointer !important;
   font-size: 18px;
   font-weight: bold;
 }
 
-.nav-tabs > li.active > a {
-  color: #005ea8;
-  border: 1px solid #0e0e0e;
-  border-bottom: transparent;
-  border-radius: 0;
-  font-weight: bold;
-  font-size: 18px;
+.nav-item > a:hover {
+  border-color: #dddddd !important;
 }
 
 .sidebar-column {

--- a/src/Components/ReturnForm/stories.js
+++ b/src/Components/ReturnForm/stories.js
@@ -7,6 +7,22 @@ storiesOf("Return Form", module).add("Simple form", () => {
   let schema = {
     type: "object",
     properties: {
+      dogs: {
+        type: "object",
+        title: "Dogs",
+        properties: {
+          catDetails: {
+            title: 'Details',
+            type: 'object',
+            properties: {
+              name: {
+                type: "string",
+                title: "Name"
+              }
+            }
+          }
+        }
+      },
       cats: {
         type: "object",
         title: "Cats",
@@ -28,6 +44,23 @@ storiesOf("Return Form", module).add("Simple form", () => {
                 title: "Fluffiness",
                 enum: ["Slightly fluffy", "Very fluffy", "Too fluffy"],
                 enumName: ["slightly", "very", "too"]
+              },
+              ancestors: {
+                type: "array",
+                title: "Ancestry",
+                items: {
+                  type: "object",
+                  properties: {
+                    name: {
+                      title: "Name",
+                      type: "string"
+                    },
+                    breed: {
+                      title: "Breed",
+                      type: "string"
+                    }
+                  }
+                }
               }
             }
           }

--- a/src/Components/Sidebar/style.css
+++ b/src/Components/Sidebar/style.css
@@ -9,4 +9,5 @@
 
 .sidebar-item {
   color: black;
+  cursor: pointer;
 }


### PR DESCRIPTION
What:  
<img width="1427" alt="css" src="https://user-images.githubusercontent.com/41294831/45171616-c0d62480-b1fa-11e8-97f1-f596c6a1895e.png">

- Makes the storybook represent more UI elements
- Adds CSS for hovering over an unselected navigator
- Makes sidebar items and view navigators switch cursor to a pointer  
- Fixes the form bouncing when selecting navigators
  
Why:  To make it clear to the user that these items are indeed clickable.