### PR TITLE
Update uischema generation to support dependencies

### DIFF
--- a/src/UseCase/GenerateUISchema/generateUISchema.test.js
+++ b/src/UseCase/GenerateUISchema/generateUISchema.test.js
@@ -268,7 +268,7 @@ describe("GenerateUISchema", () => {
 
   describe("Horizontal", () => {
     describe("Given an array with horizontal items", () => {
-      fit("Sets the UI field to horizontal", () => {
+      it("Sets the UI field to horizontal", () => {
         let schema = {
           type: "object",
           properties: {
@@ -288,10 +288,10 @@ describe("GenerateUISchema", () => {
         expect(response).toEqual({
           a: {
             items: { "ui:field": "horizontal" },
-            "ui:options": { 
-              addable: false, 
-              orderable: false, 
-              removable: false 
+            "ui:options": {
+              addable: false,
+              orderable: false,
+              removable: false
             }
           }
         });
@@ -358,6 +358,218 @@ describe("GenerateUISchema", () => {
               expect(response).toEqual({
                 a: { "ui:field": "horizontal", b: { "ui:disabled": true } }
               });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe("With Dependencies", () => {
+    describe("With a single dependency", () => {
+      describe("Inside an object", () => {
+        describe("Example one", () => {
+          it("Sets the UI schema for dependencies", () => {
+            let schema = {
+              type: "object",
+              properties: {
+                a: {
+                  type: "object",
+                  properties: {
+                    cats: { readonly: true }
+                  },
+                  dependencies: {
+                    x: {
+                      oneOf: [
+                        {
+                          properties: {
+                            meow: {
+                              type: "object",
+                              horizontal: true,
+                              properties: {}
+                            },
+                            quack: { readonly: true }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            };
+
+            let response = useCase.execute(schema);
+
+            expect(response).toEqual({
+              a: {
+                cats: { "ui:disabled": true },
+                meow: { "ui:field": "horizontal" },
+                quack: { "ui:disabled": true }
+              }
+            });
+          });
+        });
+
+        describe("Example two", () => {
+          it("Sets the UI field to horizontal", () => {
+            let schema = {
+              type: "object",
+              properties: {
+                b: {
+                  type: "object",
+                  properties: {
+                    dogs: { readonly: true }
+                  },
+                  dependencies: {
+                    y: {
+                      oneOf: [
+                        {
+                          properties: {
+                            woof: {
+                              type: "object",
+                              horizontal: true,
+                              properties: {}
+                            },
+                            moo: { readonly: true }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            };
+
+            let response = useCase.execute(schema);
+
+            expect(response).toEqual({
+              b: {
+                dogs: { "ui:disabled": true },
+                woof: { "ui:field": "horizontal" },
+                moo: { "ui:disabled": true }
+              }
+            });
+          });
+        });
+      });
+    });
+
+    describe("With multiple dependencies", () => {
+      describe("Inside an object", () => {
+        describe("Example one", () => {
+          it("Sets the UI schema for dependencies", () => {
+            let schema = {
+              type: "object",
+              properties: {
+                a: {
+                  type: "object",
+                  properties: {},
+                  dependencies: {
+                    z: {
+                      oneOf: [
+                        {
+                          properties: {
+                            meow: {
+                              type: "object",
+                              horizontal: true,
+                              properties: {}
+                            },
+                            quack: {
+                              type: "array",
+                              addable: true,
+                              items: {
+                                type: "object",
+                                properties: {}
+                              }
+                            }
+                          }
+                        },
+                        {
+                          properties: {
+                            chirp: {
+                              type: "array",
+                              addable: true,
+                              items: { type: "object", properties: {} }
+                            },
+                            squeak: { readonly: true }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            };
+
+            let response = useCase.execute(schema);
+
+            expect(response).toEqual({
+              a: {
+                meow: { "ui:field": "horizontal" },
+                quack: {
+                  items: {},
+                  "ui:options": {
+                    addable: true,
+                    orderable: false,
+                    removable: true
+                  }
+                },
+                chirp: {
+                  items: {},
+                  "ui:options": {
+                    addable: true,
+                    orderable: false,
+                    removable: true
+                  }
+                },
+                squeak: { "ui:disabled": true }
+              }
+            });
+          });
+        });
+
+        describe("Example two", () => {
+          it("Sets the UI field to horizontal", () => {
+            let schema = {
+              type: "object",
+              properties: {
+                b: {
+                  type: "object",
+                  properties: {},
+                  dependencies: {
+                    q: {
+                      oneOf: [
+                        {
+                          properties: {
+                            woof: {
+                              type: "object",
+                              horizontal: true,
+                              properties: {}
+                            },
+                            moo: { readonly: true }
+                          }
+                        },
+                        {
+                          properties: {
+                            bark: { type: "string" },
+                            cluck: { readonly: true }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            };
+
+            let response = useCase.execute(schema);
+
+            expect(response).toEqual({
+              b: {
+                woof: { "ui:field": "horizontal" },
+                moo: { "ui:disabled": true },
+                cluck: { "ui:disabled": true }
+              }
             });
           });
         });

--- a/src/UseCase/GenerateUISchema/index.js
+++ b/src/UseCase/GenerateUISchema/index.js
@@ -8,27 +8,56 @@ export default class GenerateUISchema {
 
     Object.entries(data).forEach(([key, value]) => {
       if (value.type === "object") {
-        ret[key] = this.generateUISchema(value.properties);
-
-        if (value.horizontal) {
-          ret[key]["ui:field"] = "horizontal";
-        }
+        ret[key] = this.generateSchemaForObject(value);
       } else if (value.type === "array") {
-        ret[key] = {};
-        ret[key]["ui:options"] = {
-          addable: this.isAddableArray(value),
-          orderable: false,
-          removable: this.isAddableArray(value)
-        };
-        ret[key]["items"] = this.generateUISchema(value.items.properties);
-        if (value.items.horizontal) {
-          ret[key]["items"]["ui:field"] = "horizontal";
-        }
+        ret[key] = this.generateSchemaForArray(value);
       } else if (value.readonly) {
         ret[key] = { "ui:disabled": true };
       }
     });
     return ret;
+  }
+
+  generateSchemaForObject(value) {
+    let ret = this.generateUISchema(value.properties);
+
+    if (value.horizontal) {
+      ret["ui:field"] = "horizontal";
+    }
+
+    if (value.dependencies) {
+      let dependencySchema = this.generateSchemaForDependencies(value);
+      ret = { ...ret, ...dependencySchema };
+    }
+
+    return ret;
+  }
+
+  generateSchemaForArray(value) {
+    let ret = {};
+    ret["ui:options"] = {
+      addable: this.isAddableArray(value),
+      orderable: false,
+      removable: this.isAddableArray(value)
+    };
+
+    ret["items"] = this.generateUISchema(value.items.properties);
+
+    if (value.items.horizontal) {
+      ret["items"]["ui:field"] = "horizontal";
+    }
+
+    return ret;
+  }
+
+  generateSchemaForDependencies(value) {
+    let reducer = (acc, dependency) => ({
+      ...acc,
+      ...this.generateSchemaForObject(dependency)
+    });
+
+    let dependencies = Object.values(value.dependencies)[0];
+    return dependencies.oneOf.reduce(reducer, {});
   }
 
   isAddableArray(arr) {


### PR DESCRIPTION
WHAT - Updates UISchema generation to support dependencies by looping over them and generating a schema much like objects/arrays

WHY - To support dynamic show/hiding our fields had to be moved to dependencies, which broke things like horizontal. This change fixes that