### PR TITLE
Add completed status to variance field

### DIFF
--- a/src/Components/VarianceField/index.js
+++ b/src/Components/VarianceField/index.js
@@ -14,8 +14,15 @@ export default class VarianceField extends React.Component {
       percentComplete: formData.percentComplete || 0,
       status: formData.status || "On schedule",
       current: formData.current || "",
-      reason: formData.reason || ""
+      reason: formData.reason || "",
+      completedDate: formData.completedDate || ""
     };
+  };
+
+  onFieldChange = (name, e) => {
+    this.setState({ [name]: e.target.value }, () => {
+      this.props.onChange(this.state);
+    });
   };
 
   renderCurrentValue = () => (
@@ -56,11 +63,23 @@ export default class VarianceField extends React.Component {
     </div>
   );
 
-  onFieldChange = (name, e) => {
-    this.setState({ [name]: e.target.value }, () => {
-      this.props.onChange(this.state);
-    });
-  };
+  renderCompletedDate = () => (
+    <div className="row">
+      <div className="col-md-3 form-group">
+        <label htmlFor="completed">Completed Date</label>
+        <input
+          className="form-control"
+          data-test="variance-completed"
+          id="completed"
+          onChange={e => this.onFieldChange("completedDate", e)}
+          type="text"
+          value={this.state.completedDate}
+        />
+      </div>
+    </div>
+  );
+
+  renderCompleted = () => <div>{this.renderCompletedDate()}</div>;
 
   renderTitle = () => (
     <div className="panel-heading" data-test="field-title">
@@ -89,6 +108,7 @@ export default class VarianceField extends React.Component {
       >
         <option>On schedule</option>
         <option>Delayed</option>
+        <option>Completed</option>
       </select>
     </div>
   );
@@ -115,6 +135,7 @@ export default class VarianceField extends React.Component {
         {this.renderPercentComplete()}
       </div>
       {this.state.status == "Delayed" && this.renderDelayed()}
+      {this.state.status == "Completed" && this.renderCompleted()}
     </div>
   );
 
@@ -132,9 +153,10 @@ VarianceField.propTypes = {
   formData: PropTypes.shape({
     baseline: PropTypes.string.isRequired,
     percentComplete: PropTypes.number,
-    status: PropTypes.oneOf(["Delayed", "On schedule"]),
+    status: PropTypes.oneOf(["Delayed", "On schedule", "Completed"]),
     current: PropTypes.string,
-    reason: PropTypes.string
+    reason: PropTypes.string,
+    completedDate: PropTypes.string
   }).isRequired,
   onChange: PropTypes.func.isRequired,
   schema: PropTypes.object.isRequired

--- a/src/Components/VarianceField/stories.js
+++ b/src/Components/VarianceField/stories.js
@@ -37,4 +37,22 @@ storiesOf("Variance", module)
       onChange={formData => console.log(formData)}
       schema={{ title: "Storybook variance" }}
     />
+  ))
+  .add("Completed", () => (
+    <VarianceField
+      formData={{ baseline: "2020-01-01", status: "Completed" }}
+      onChange={formData => console.log(formData)}
+      schema={{ title: "Storybook variance" }}
+    />
+  ))
+  .add("Completed with data", () => (
+    <VarianceField
+      formData={{
+        baseline: "2020-01-01",
+        status: "Completed",
+        completedDate: "2025-01-01"
+      }}
+      onChange={formData => console.log(formData)}
+      schema={{ title: "Storybook variance" }}
+    />
   ));

--- a/src/Components/VarianceField/varianceField.test.js
+++ b/src/Components/VarianceField/varianceField.test.js
@@ -51,6 +51,11 @@ describe("VarianceField", () => {
         expect(reason.length).toEqual(0);
       });
 
+      it("Does not show the completed date field", () => {
+        let completedDate = field.find("[data-test='variance-completed']");
+        expect(completedDate.length).toEqual(0);
+      });
+
       describe("When selecting Delayed", () => {
         beforeEach(() => {
           let status = field.find("[data-test='variance-status']");
@@ -65,6 +70,18 @@ describe("VarianceField", () => {
         it("Shows the reason for variance field", () => {
           let reason = field.find("[data-test='variance-reason']");
           expect(reason.length).toEqual(1);
+        });
+      });
+
+      describe("When selecting completed", () => {
+        beforeEach(() => {
+          let status = field.find("[data-test='variance-status']");
+          status.simulate("change", { target: { value: "Completed" } });
+        });
+
+        it("Shows the completed date field", () => {
+          let completedDate = field.find("[data-test='variance-completed']");
+          expect(completedDate.length).toEqual(1);
         });
       });
     });
@@ -128,6 +145,18 @@ describe("VarianceField", () => {
         it("Shows the reason for variance field", () => {
           let reason = field.find("[data-test='variance-reason']");
           expect(reason.length).toEqual(1);
+        });
+      });
+
+      describe("When selecting completed", () => {
+        beforeEach(() => {
+          let status = field.find("[data-test='variance-status']");
+          status.simulate("change", { target: { value: "Completed" } });
+        });
+
+        it("Shows the completed date field", () => {
+          let completedDate = field.find("[data-test='variance-completed']");
+          expect(completedDate.length).toEqual(1);
         });
       });
     });
@@ -263,142 +292,261 @@ describe("VarianceField", () => {
         });
       });
     });
+
+    describe("When completed", () => {
+      describe("Example one", () => {
+        it("Fills in the completed date correctly", () => {
+          let schema = { title: "Meow Meow Fuzzyface" };
+          let formData = {
+            baseline: "2020-12-31",
+            status: "Completed",
+            percentComplete: 100,
+            completedDate: "2021-01-01"
+          };
+          let field = shallow(
+            <VarianceField
+              schema={schema}
+              formData={formData}
+              onChange={jest.fn()}
+            />
+          );
+
+          let completedDate = field
+            .find("[data-test='variance-completed']")
+            .props().value;
+
+          expect(completedDate).toEqual("2021-01-01");
+        });
+      });
+
+      describe("Example two", () => {
+        it("Fills in the completed date correctly", () => {
+          let schema = { title: "Meow Meow Fuzzyface" };
+          let formData = {
+            baseline: "2020-12-31",
+            status: "Completed",
+            percentComplete: 100,
+            completedDate: "2025-01-01"
+          };
+          let field = shallow(
+            <VarianceField
+              schema={schema}
+              formData={formData}
+              onChange={jest.fn()}
+            />
+          );
+
+          let completedDate = field
+            .find("[data-test='variance-completed']")
+            .props().value;
+
+          expect(completedDate).toEqual("2025-01-01");
+        });
+      });
+    });
   });
 
   describe("When updating fields", () => {
     let onChangeSpy;
-    beforeEach(() => {
-      onChangeSpy = jest.fn();
-      let schema = { title: "Meow Meow Fuzzyface" };
-      let formData = {
-        baseline: "2020-12-31",
-        status: "Delayed",
-        percentComplete: 10,
-        current: "2050-01-01",
-        reason: "Super delays"
-      };
-      field = shallow(
-        <VarianceField
-          schema={schema}
-          formData={formData}
-          onChange={onChangeSpy}
-        />
-      );
-    });
 
-    describe("When changing the status", () => {
-      it("Calls the onChange prop with the updated form data", () => {
-        field
-          .find("[data-test='variance-status']")
-          .simulate("change", { target: { value: "On schedule" } });
-
-        expect(onChangeSpy).toHaveBeenCalledWith({
+    describe("When delayed", () => {
+      beforeEach(() => {
+        onChangeSpy = jest.fn();
+        let schema = { title: "Meow Meow Fuzzyface" };
+        let formData = {
           baseline: "2020-12-31",
-          status: "On schedule",
+          status: "Delayed",
           percentComplete: 10,
           current: "2050-01-01",
           reason: "Super delays"
+        };
+        field = shallow(
+          <VarianceField
+            schema={schema}
+            formData={formData}
+            onChange={onChangeSpy}
+          />
+        );
+      });
+
+      describe("When changing the status", () => {
+        it("Calls the onChange prop with the updated form data", () => {
+          field
+            .find("[data-test='variance-status']")
+            .simulate("change", { target: { value: "On schedule" } });
+
+          expect(onChangeSpy).toHaveBeenCalledWith({
+            baseline: "2020-12-31",
+            status: "On schedule",
+            percentComplete: 10,
+            current: "2050-01-01",
+            reason: "Super delays",
+            completedDate: ""
+          });
+        });
+      });
+
+      describe("When changing the percent complete", () => {
+        describe("Example one", () => {
+          it("Calls the onChange prop with the updated form data", () => {
+            field
+              .find("[data-test='variance-percentage']")
+              .simulate("change", { target: { value: 15 } });
+
+            expect(onChangeSpy).toHaveBeenCalledWith({
+              baseline: "2020-12-31",
+              status: "Delayed",
+              percentComplete: 15,
+              current: "2050-01-01",
+              reason: "Super delays",
+              completedDate: ""
+            });
+          });
+        });
+
+        describe("Example two", () => {
+          it("Calls the onChange prop with the updated form data", () => {
+            field
+              .find("[data-test='variance-percentage']")
+              .simulate("change", { target: { value: 90 } });
+
+            expect(onChangeSpy).toHaveBeenCalledWith({
+              baseline: "2020-12-31",
+              status: "Delayed",
+              percentComplete: 90,
+              current: "2050-01-01",
+              reason: "Super delays",
+              completedDate: ""
+            });
+          });
+        });
+      });
+
+      describe("When changing the current value", () => {
+        describe("Example one", () => {
+          it("Calls the onChange prop with the updated form data", () => {
+            field
+              .find("[data-test='variance-current']")
+              .simulate("change", { target: { value: "2040-01-01" } });
+
+            expect(onChangeSpy).toHaveBeenCalledWith({
+              baseline: "2020-12-31",
+              status: "Delayed",
+              percentComplete: 10,
+              current: "2040-01-01",
+              reason: "Super delays",
+              completedDate: ""
+            });
+          });
+        });
+
+        describe("Example two", () => {
+          it("Calls the onChange prop with the updated form data", () => {
+            field
+              .find("[data-test='variance-current']")
+              .simulate("change", { target: { value: "2020-05-01" } });
+
+            expect(onChangeSpy).toHaveBeenCalledWith({
+              baseline: "2020-12-31",
+              status: "Delayed",
+              percentComplete: 10,
+              current: "2020-05-01",
+              reason: "Super delays",
+              completedDate: ""
+            });
+          });
+        });
+      });
+
+      describe("When changing the reason value", () => {
+        describe("Example one", () => {
+          it("Calls the onChange prop with the updated form data", () => {
+            field
+              .find("[data-test='variance-reason']")
+              .simulate("change", { target: { value: "Mega delays" } });
+
+            expect(onChangeSpy).toHaveBeenCalledWith({
+              baseline: "2020-12-31",
+              status: "Delayed",
+              percentComplete: 10,
+              current: "2050-01-01",
+              reason: "Mega delays",
+              completedDate: ""
+            });
+          });
+        });
+
+        describe("Example two", () => {
+          it("Calls the onChange prop with the updated form data", () => {
+            field.find("[data-test='variance-reason']").simulate("change", {
+              target: { value: "Just the worst delays" }
+            });
+
+            expect(onChangeSpy).toHaveBeenCalledWith({
+              baseline: "2020-12-31",
+              status: "Delayed",
+              percentComplete: 10,
+              current: "2050-01-01",
+              reason: "Just the worst delays",
+              completedDate: ""
+            });
+          });
         });
       });
     });
 
-    describe("When changing the percent complete", () => {
-      describe("Example one", () => {
-        it("Calls the onChange prop with the updated form data", () => {
-          field
-            .find("[data-test='variance-percentage']")
-            .simulate("change", { target: { value: 15 } });
-
-          expect(onChangeSpy).toHaveBeenCalledWith({
-            baseline: "2020-12-31",
-            status: "Delayed",
-            percentComplete: 15,
-            current: "2050-01-01",
-            reason: "Super delays"
-          });
-        });
+    describe("When completed", () => {
+      beforeEach(() => {
+        onChangeSpy = jest.fn();
+        let schema = { title: "Meow Meow Fuzzyface" };
+        let formData = {
+          baseline: "2020-12-31",
+          status: "Completed",
+          percentComplete: 100,
+          current: "",
+          reason: ""
+        };
+        field = shallow(
+          <VarianceField
+            schema={schema}
+            formData={formData}
+            onChange={onChangeSpy}
+          />
+        );
       });
 
-      describe("Example two", () => {
-        it("Calls the onChange prop with the updated form data", () => {
-          field
-            .find("[data-test='variance-percentage']")
-            .simulate("change", { target: { value: 90 } });
+      describe("When changing the completed date", () => {
+        describe("Example one", () => {
+          it("Calls the onChange prop with the updated form data", () => {
+            field
+              .find("[data-test='variance-completed']")
+              .simulate("change", { target: { value: "2020-01-01" } });
 
-          expect(onChangeSpy).toHaveBeenCalledWith({
-            baseline: "2020-12-31",
-            status: "Delayed",
-            percentComplete: 90,
-            current: "2050-01-01",
-            reason: "Super delays"
+            expect(onChangeSpy).toHaveBeenCalledWith({
+              baseline: "2020-12-31",
+              status: "Completed",
+              percentComplete: 100,
+              current: "",
+              reason: "",
+              completedDate: "2020-01-01"
+            });
           });
         });
-      });
-    });
 
-    describe("When changing the current value", () => {
-      describe("Example one", () => {
-        it("Calls the onChange prop with the updated form data", () => {
-          field
-            .find("[data-test='variance-current']")
-            .simulate("change", { target: { value: "2040-01-01" } });
+        describe("Example one", () => {
+          it("Calls the onChange prop with the updated form data", () => {
+            field
+              .find("[data-test='variance-completed']")
+              .simulate("change", { target: { value: "2025-01-01" } });
 
-          expect(onChangeSpy).toHaveBeenCalledWith({
-            baseline: "2020-12-31",
-            status: "Delayed",
-            percentComplete: 10,
-            current: "2040-01-01",
-            reason: "Super delays"
-          });
-        });
-      });
-
-      describe("Example two", () => {
-        it("Calls the onChange prop with the updated form data", () => {
-          field
-            .find("[data-test='variance-current']")
-            .simulate("change", { target: { value: "2020-05-01" } });
-
-          expect(onChangeSpy).toHaveBeenCalledWith({
-            baseline: "2020-12-31",
-            status: "Delayed",
-            percentComplete: 10,
-            current: "2020-05-01",
-            reason: "Super delays"
-          });
-        });
-      });
-    });
-
-    describe("When changing the reason value", () => {
-      describe("Example one", () => {
-        it("Calls the onChange prop with the updated form data", () => {
-          field
-            .find("[data-test='variance-reason']")
-            .simulate("change", { target: { value: "Mega delays" } });
-
-          expect(onChangeSpy).toHaveBeenCalledWith({
-            baseline: "2020-12-31",
-            status: "Delayed",
-            percentComplete: 10,
-            current: "2050-01-01",
-            reason: "Mega delays"
-          });
-        });
-      });
-
-      describe("Example two", () => {
-        it("Calls the onChange prop with the updated form data", () => {
-          field
-            .find("[data-test='variance-reason']")
-            .simulate("change", { target: { value: "Just the worst delays" } });
-
-          expect(onChangeSpy).toHaveBeenCalledWith({
-            baseline: "2020-12-31",
-            status: "Delayed",
-            percentComplete: 10,
-            current: "2050-01-01",
-            reason: "Just the worst delays"
+            expect(onChangeSpy).toHaveBeenCalledWith({
+              baseline: "2020-12-31",
+              status: "Completed",
+              percentComplete: 100,
+              current: "",
+              reason: "",
+              completedDate: "2025-01-01"
+            });
           });
         });
       });


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/976254/45817211-ec1a4280-bcd5-11e8-9196-7f7d8795bc8a.png)


WHAT
- Adds the ability to set a completed status

WHY
- Once something is completed, the user should enter the completion date