### PR TITLE
Add Risk Field Component

### DIFF
--- a/src/Components/RiskField/index.js
+++ b/src/Components/RiskField/index.js
@@ -1,0 +1,164 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+export default class RiskField extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      riskBaselineRisk: this.props.formData.riskBaselineRisk ,
+      riskBaselineImpact: this.props.formData.riskBaselineImpact,
+      riskBaselineLikelihood: this.props.formData.riskBaselineLikelihood,
+      riskBaselineMitigationsInPlace:
+        this.props.formData.riskBaselineMitigationsInPlace,
+      riskCurrentReturnLikelihood:
+        this.props.formData.riskCurrentReturnLikelihood || "1",
+      riskChangeRisk: this.props.formData.riskChangeRisk || "No",
+      riskCurrentMitigationsInPlace:
+        this.props.formData.riskCurrentMitigationsInPlace 
+    };
+  }
+
+  onFieldChange = (name, e) => {
+    this.setState({ [name]: e.target.value }, () => {
+      this.props.onChange(this.state);
+    });
+  };
+
+  renderRiskDescription = () => (
+    <div>
+      <h5>
+        <b>Description of Risk</b>
+      </h5>
+      <p data-test="risk-description">{this.props.formData.riskBaselineRisk}</p>
+    </div>
+  );
+
+  renderRiskBaselineImpact = () => (
+    <div className="col-md-3">
+      <h5>Impact:</h5>
+      <p data-test="risk-impact">{this.props.formData.riskBaselineImpact}</p>
+    </div>
+  );
+
+  renderRiskLikelihood = () => (
+    <div className="col-md-3">
+      <h5>Likelihood:</h5>
+      <p data-test="risk-likelihood">
+        {this.props.formData.riskBaselineLikelihood}
+      </p>
+    </div>
+  );
+
+  renderRiskMitigationInPlace = () => (
+    <div className="col-md-6">
+      <h5>
+        <b>Mitigation in place</b>
+      </h5>
+      <p data-test="risk-mitigation-in-place">
+        {this.props.formData.riskBaselineMitigationsInPlace}
+      </p>
+    </div>
+  );
+
+  renderCurrentReturnLikelihood = () => (
+    <div className="col-md-3">
+      <div className="row">
+        <div className="col-md-12">
+          <label htmlFor="currentReturnLikelihood">
+            Current Return Likelihood{" "}
+          </label>
+        </div>
+        <div row="row">
+          <div className="col-md-12">
+            <select
+              onChange={e =>
+                this.onFieldChange("riskCurrentReturnLikelihood", e)
+              }
+              data-test="risk-current-likelihood"
+              value={this.state.riskCurrentReturnLikelihood}
+              className="form-control"
+              id="currentReturnLikelihood"
+            >
+              <option>1</option>
+              <option>2</option>
+              <option>3</option>
+              <option>4</option>
+              <option>5</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  renderChangeInRisk = () => (
+    <div className="col-md-3">
+      <div className="row">
+        <div className="col-md-12">
+          <label htmlFor="anyChangeInRisk">Any Change in Risk? </label>
+        </div>
+      </div>
+      <div className="row">
+        <div className="col-md-12">
+          <select
+            onChange={e => this.onFieldChange("riskChangeRisk", e)}
+            data-test="risk-change-in-risk"
+            value={this.state.riskChangeRisk}
+            className="form-control"
+            id="anyChangeInRisk"
+          >
+            <option>Yes</option>
+            <option>No</option>
+          </select>
+        </div>
+      </div>
+    </div>
+  );
+
+  renderCurrentMitigationsInPlace = () => (
+    <div className="col-md-6">
+      <label htmlFor="currentReturnMitigationInPlace">
+        Current Return Mitigation in Place
+      </label>
+      <textarea
+        className="form-control"
+        id="currentReturnMitigationInPlace"
+        onChange={e => this.onFieldChange("riskCurrentMitigationsInPlace", e)}
+        data-test="risk-current-mitigations-in-place"
+        value={this.state.riskCurrentMitigationsInPlace}
+      />
+    </div>
+  );
+
+  renderBody = () => (
+    <div className="panel-body">
+      <div className="row">
+        <div className="col-md-6">
+          {this.renderRiskDescription()}
+          <div className="row">
+            {this.renderRiskBaselineImpact()}
+            {this.renderRiskLikelihood()}
+            <div className="col-md-6" />
+          </div>
+        </div>
+        {this.renderRiskMitigationInPlace()}
+      </div>
+      <div className="row">&nbsp;</div>
+      <div className="row">
+        {this.renderCurrentReturnLikelihood()}
+        {this.renderChangeInRisk()}
+        {this.renderCurrentMitigationsInPlace()}
+      </div>
+    </div>
+  );
+
+  render() {
+    return (
+      <div className="panel panel-default">
+        <div className="panel-heading" data-test="schema-title">{this.props.schema.title}</div>
+        {this.renderBody()}
+      </div>
+    );
+  }
+}

--- a/src/Components/RiskField/riskField.test.js
+++ b/src/Components/RiskField/riskField.test.js
@@ -1,0 +1,367 @@
+import RiskField from ".";
+import React from "react";
+import { shallow } from "enzyme";
+
+class RiskComponent {
+  constructor(formData, onChange, schemaTitle) {
+    this.risk = shallow(
+      <RiskField
+        schema={{ title: schemaTitle }}
+        formData={formData}
+        onChange={onChange}
+      />
+    );
+  }
+  description = () => this.risk.find("[data-test='risk-description']").text();
+
+  impact = () => this.risk.find("[data-test='risk-impact']").text();
+
+  likelihood = () => this.risk.find("[data-test='risk-likelihood']").text();
+
+  title = () => this.risk.find("[data-test='schema-title']").text();
+
+  mitigationsInPlace = () =>
+    this.risk.find("[data-test='risk-mitigation-in-place']").text();
+
+  simulateCurrentLikelihood = inputValue =>
+    this.risk
+      .find("[data-test='risk-current-likelihood']")
+      .simulate("change", { target: { value: inputValue } });
+
+  simulateChangeInRisk = inputValue =>
+    this.risk
+      .find("[data-test='risk-change-in-risk']")
+      .simulate("change", { target: { value: inputValue } });
+
+  simulateCurrentMitigationInPlace = inputValue =>
+    this.risk
+      .find("[data-test='risk-current-mitigations-in-place']")
+      .simulate("change", { target: { value: inputValue } });
+
+  findReturnLikelihoodValue = () =>
+    this.risk.find("[data-test='risk-current-likelihood']").props().value;
+
+  findChangeInRiskValue = () =>
+    this.risk.find("[data-test='risk-change-in-risk']").props().value;
+
+  findCurrentMitigationsInPlaceValue = () =>
+    this.risk.find("[data-test='risk-current-mitigations-in-place']").props()
+      .value;
+}
+
+describe("<RiskField>", () => {
+  let onChangeSpy = jest.fn();
+  describe("Given baseline data", () => {
+    describe("Example 1", () => {
+      let formData = {
+        riskBaselineRisk: "This is a very risky risk.",
+        riskBaselineImpact: "1",
+        riskBaselineLikelihood: "2",
+        riskBaselineMitigationsInPlace: "This cat is mitigating the risk"
+      };
+      let schemaTitle = "Risk Fields"
+      let risk = new RiskComponent(formData, onChangeSpy, schemaTitle);
+      
+      it("displays the schema title", () => {
+        expect(risk.title()).toEqual("Risk Fields");
+      });
+
+      it("displays the risk description", () => {
+        expect(risk.description()).toEqual("This is a very risky risk.");
+      });
+
+      it("displays the impact", () => {
+        expect(risk.impact()).toEqual("1");
+      });
+
+      it("displays the likelihood", () => {
+        expect(risk.likelihood()).toEqual("2");
+      });
+
+      it("displays the mitigiation in place", () => {
+        expect(risk.mitigationsInPlace()).toEqual(
+          "This cat is mitigating the risk"
+        );
+      });
+    });
+    describe("Example 2", () => {
+      let formData = {
+        riskBaselineRisk:
+          "This is a much less risky risk. The cat might get stuck up the tree.",
+        riskBaselineImpact: "4",
+        riskBaselineLikelihood: "5",
+        riskBaselineMitigationsInPlace:
+          "This dog is trying to mitigate the risk"
+      };
+      let schemaTitle = "More Risky Field Data"
+      let risk = new RiskComponent(formData, onChangeSpy, schemaTitle);
+
+      it("displays the schema title", () => {
+        expect(risk.title()).toEqual("More Risky Field Data");
+      });
+
+      it("displays the risk description", () => {
+        expect(risk.description()).toEqual(
+          "This is a much less risky risk. The cat might get stuck up the tree."
+        );
+      });
+
+      it("displays the impact", () => {
+        expect(risk.impact()).toEqual("4");
+      });
+
+      it("displays the likelihood", () => {
+        expect(risk.likelihood()).toEqual("5");
+      });
+
+      it("displays the mitigiation in place", () => {
+        expect(risk.mitigationsInPlace()).toEqual(
+          "This dog is trying to mitigate the risk"
+        );
+      });
+    });
+  });
+  describe("When updating fields", () => {
+    let risk;
+    beforeEach(() => {
+      let formData = {
+        riskBaselineRisk: "Cat gets stuck in the tree",
+        riskBaselineImpact: "3",
+        riskBaselineLikelihood: "4",
+        riskBaselineMitigationsInPlace: "Cut down the tree"
+      };
+      risk = new RiskComponent(formData, onChangeSpy);
+    });
+
+    describe("When selecting a current return likelihood", () => {
+      describe("Example 1", () => {
+        it("Updates the value of the field", () => {
+          risk.simulateCurrentLikelihood("2");
+
+          expect(onChangeSpy).toHaveBeenCalledWith({
+            riskBaselineRisk: "Cat gets stuck in the tree",
+            riskBaselineImpact: "3",
+            riskBaselineLikelihood: "4",
+            riskBaselineMitigationsInPlace: "Cut down the tree",
+            riskCurrentReturnLikelihood: "2",
+            riskChangeRisk: "No",
+            riskCurrentMitigationsInPlace: undefined
+          });
+        });
+      });
+
+      describe("Example 2", () => {
+        it("Updates the value of the field", () => {
+          risk.simulateCurrentLikelihood("5");
+
+          expect(onChangeSpy).toHaveBeenCalledWith({
+            riskBaselineRisk: "Cat gets stuck in the tree",
+            riskBaselineImpact: "3",
+            riskBaselineLikelihood: "4",
+            riskBaselineMitigationsInPlace: "Cut down the tree",
+            riskCurrentReturnLikelihood: "5",
+            riskChangeRisk: "No",
+            riskCurrentMitigationsInPlace: undefined
+          });
+        });
+      });
+    });
+    describe("When selecting a change in risk", () => {
+      describe("Example 1", () => {
+        it("Updates the value of the field", () => {
+          risk.simulateChangeInRisk("Yes");
+
+          expect(onChangeSpy).toHaveBeenCalledWith({
+            riskBaselineRisk: "Cat gets stuck in the tree",
+            riskBaselineImpact: "3",
+            riskBaselineLikelihood: "4",
+            riskBaselineMitigationsInPlace: "Cut down the tree",
+            riskCurrentReturnLikelihood: "1",
+            riskChangeRisk: "Yes",
+            riskCurrentMitigationsInPlace: undefined
+          });
+        });
+      });
+
+      describe("Example 2", () => {
+        it("Updates the value of the field", () => {
+          risk.simulateChangeInRisk("No");
+
+          expect(onChangeSpy).toHaveBeenCalledWith({
+            riskBaselineRisk: "Cat gets stuck in the tree",
+            riskBaselineImpact: "3",
+            riskBaselineLikelihood: "4",
+            riskBaselineMitigationsInPlace: "Cut down the tree",
+            riskCurrentReturnLikelihood: "1",
+            riskChangeRisk: "No",
+            riskCurrentMitigationsInPlace: undefined
+          });
+        });
+      });
+    });
+    describe("When selecting a change in current mitigations in place", () => {
+      describe("Example 1", () => {
+        it("Updates the value of the field", () => {
+          risk.simulateCurrentMitigationInPlace(
+            "We haven't done anything yet, stop nagging!"
+          );
+
+          expect(onChangeSpy).toHaveBeenCalledWith({
+            riskBaselineRisk: "Cat gets stuck in the tree",
+            riskBaselineImpact: "3",
+            riskBaselineLikelihood: "4",
+            riskBaselineMitigationsInPlace: "Cut down the tree",
+            riskCurrentReturnLikelihood: "1",
+            riskChangeRisk: "No",
+            riskCurrentMitigationsInPlace:
+              "We haven't done anything yet, stop nagging!"
+          });
+        });
+      });
+
+      describe("Example 2", () => {
+        it("Updates the value of the field", () => {
+          risk.simulateCurrentMitigationInPlace("Please, give us more time!");
+
+          expect(onChangeSpy).toHaveBeenCalledWith({
+            riskBaselineRisk: "Cat gets stuck in the tree",
+            riskBaselineImpact: "3",
+            riskBaselineLikelihood: "4",
+            riskBaselineMitigationsInPlace: "Cut down the tree",
+            riskCurrentReturnLikelihood: "1",
+            riskChangeRisk: "No",
+            riskCurrentMitigationsInPlace: "Please, give us more time!"
+          });
+        });
+      });
+    });
+  });
+  describe("Given pre-populated form data", () => {
+    describe("Example 1", () => {
+      let risk;
+      beforeEach(() => {
+        let formData = {
+          riskBaselineRisk: "Cat gets stuck in the tree",
+          riskBaselineImpact: "3",
+          riskBaselineLikelihood: "4",
+          riskBaselineMitigationsInPlace: "Cut down the tree",
+          riskCurrentReturnLikelihood: "5",
+          riskChangeRisk: "Yes",
+          riskCurrentMitigationsInPlace: "Nothing yet!"
+        };
+        risk = new RiskComponent(formData, onChangeSpy);
+      });
+
+      it("Displays the Current Return Likelihood", () => {
+        expect(risk.findReturnLikelihoodValue()).toEqual("5");
+      });
+
+      it("Displays the Change in Risk", () => {
+        expect(risk.findChangeInRiskValue()).toEqual("Yes");
+      });
+
+      it("Displays the Current Mitigation in Place", () => {
+        expect(risk.findCurrentMitigationsInPlaceValue()).toEqual(
+          "Nothing yet!"
+        );
+      });
+    });
+
+    describe("Example 2", () => {
+      let risk;
+      beforeEach(() => {
+        let formData = {
+          riskBaselineRisk: "Cat gets stuck in the tree",
+          riskBaselineImpact: "3",
+          riskBaselineLikelihood: "4",
+          riskBaselineMitigationsInPlace: "Cut down the tree",
+          riskCurrentReturnLikelihood: "3",
+          riskChangeRisk: "No",
+          riskCurrentMitigationsInPlace: "More cat teamwork!"
+        };
+        risk = new RiskComponent(formData, onChangeSpy);
+      });
+
+      it("Displays the Current Return Likelihood", () => {
+        expect(risk.findReturnLikelihoodValue()).toEqual("3");
+      });
+
+      it("Displays the Change in Risk", () => {
+        expect(risk.findChangeInRiskValue()).toEqual("No");
+      });
+
+      it("Displays the Current Mitigation in Place", () => {
+        expect(risk.findCurrentMitigationsInPlaceValue()).toEqual(
+          "More cat teamwork!"
+        );
+      });
+    });
+  });
+  describe("Changing pre-populated form data", () => {
+    describe("Example 1", () => {
+      let risk;
+      beforeEach(() => {
+        let formData = {
+          riskBaselineRisk: "Cat gets stuck in the tree",
+          riskBaselineImpact: "3",
+          riskBaselineLikelihood: "4",
+          riskBaselineMitigationsInPlace: "Cut down the tree",
+          riskCurrentReturnLikelihood: "5",
+          riskChangeRisk: "Yes",
+          riskCurrentMitigationsInPlace: "Nothing yet!"
+        };
+        risk = new RiskComponent(formData, onChangeSpy);
+      });
+
+      it("Updates the value of current return likelihood", () => {
+        risk.simulateCurrentLikelihood("2");
+        expect(risk.findReturnLikelihoodValue()).toEqual("2");
+      });
+
+      it("Updates the value of change in risk", () => {
+        risk.simulateChangeInRisk("No");
+        expect(risk.findChangeInRiskValue()).toEqual("No");
+      });
+
+      it("Updates the value of current mitigations in place", () => {
+        risk.simulateCurrentMitigationInPlace("We've done something now.");
+        expect(risk.findCurrentMitigationsInPlaceValue()).toEqual(
+          "We've done something now."
+        );
+      });
+    });
+
+    describe("Example 2", () => {
+      let risk;
+      beforeEach(() => {
+        let formData = {
+          riskBaselineRisk: "Cat gets stuck in the tree",
+          riskBaselineImpact: "3",
+          riskBaselineLikelihood: "4",
+          riskBaselineMitigationsInPlace: "Cut down the tree",
+          riskCurrentReturnLikelihood: "5",
+          riskChangeRisk: "No",
+          riskCurrentMitigationsInPlace: "Nothing yet!"
+        };
+        risk = new RiskComponent(formData, onChangeSpy);
+      });
+
+      it("Updates the value of current return likelihood", () => {
+        risk.simulateCurrentLikelihood("3");
+        expect(risk.findReturnLikelihoodValue()).toEqual("3");
+      });
+
+      it("Updates the value of change in risk", () => {
+        risk.simulateChangeInRisk("Yes");
+        expect(risk.findChangeInRiskValue()).toEqual("Yes");
+      });
+
+      it("Updates the value of current mitigations in place", () => {
+        risk.simulateCurrentMitigationInPlace("Mitigations forever.");
+        expect(risk.findCurrentMitigationsInPlaceValue()).toEqual(
+          "Mitigations forever."
+        );
+      });
+    });
+  });
+});

--- a/src/Components/RiskField/stories.js
+++ b/src/Components/RiskField/stories.js
@@ -1,0 +1,38 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import RiskField from ".";
+
+
+storiesOf("Risk", module).add("default", () => (
+  <RiskField
+    schema={{title: "Risk Storyboard"}}
+    formData={{
+      riskBaselineRisk:
+        "This is a much less risky risk. The cat might get stuck up the tree.",
+      riskBaselineImpact: "4",
+      riskBaselineLikelihood: "5",
+      riskBaselineMitigationsInPlace: "This dog is trying to mitigate the risk"
+    }}
+    onChange={formData => {
+      console.log(formData);
+    }}
+  />
+));
+storiesOf("Risk", module).add("prepopluated data", () => (
+  <RiskField
+    schema={{title: "Risk Storyboard"}}
+    formData={{
+      riskBaselineRisk:
+        "This is a much less risky risk. The cat might get stuck up the tree.",
+      riskBaselineImpact: "4",
+      riskBaselineLikelihood: "5",
+      riskBaselineMitigationsInPlace: "This dog is trying to mitigate the risk",
+      riskCurrentReturnLikelihood: "5",
+      riskChangeRisk: "No",
+      riskCurrentMitigationsInPlace: "The dog ran away, no current mitigation"
+    }}
+    onChange={formData => {
+      console.log(formData);
+    }}
+  />
+));


### PR DESCRIPTION
<img width="1211" alt="screen shot 2018-09-25 at 16 26 50" src="https://user-images.githubusercontent.com/38878719/46025032-e2cb1480-c0df-11e8-9454-86d5c071c191.png">

WHAT
- Add a component for a single risk field.

WHY
- To improve on the UX of risk fields. This is currently in a spreadsheet format which requires horizontal scrolling to view all the form data. 