### PR TITLE
Add key to form element

### DIFF
--- a/src/Components/ArraySubform/arraySubform.test.js
+++ b/src/Components/ArraySubform/arraySubform.test.js
@@ -86,6 +86,18 @@ describe("<ArraySubform>", () => {
       expect(subform.find("Form").length).toEqual(1);
     });
 
+    it("Sets the key on the form to the selected index and section", () => {
+      let subform = getSubform({
+        schema,
+        data,
+        uiSchema,
+        index: 0,
+        section: "details"
+      });
+
+      expect(subform.find("Form").key()).toEqual("0_details");
+    });
+
     it("Passes the fields to the form", () => {
       let subform = getSubform({
         schema,
@@ -162,6 +174,10 @@ describe("<ArraySubform>", () => {
         );
       });
 
+      it("Sets the key on the form to the selected index and section", () => {
+        expect(subform.find("Form").key()).toEqual("0_pets");
+      });
+
       it("Passes the selected form data to the form", () => {
         expect(subform.find("Form").props().formData).toEqual({
           favourite: "All of them"
@@ -205,6 +221,10 @@ describe("<ArraySubform>", () => {
         expect(subform.find("Form").props().formData).toEqual({
           firstName: "Barkington"
         });
+      });
+
+      it("Sets the key on the form to the selected index and section", () => {
+        expect(subform.find("Form").key()).toEqual("1_details");
       });
 
       it("Passes the updated form data to the onChange method", () => {
@@ -269,7 +289,7 @@ describe("<ArraySubform>", () => {
         contact: { phoneNo: { that: false } }
       };
 
-      fields = { bar: () => {}};
+      fields = { bar: () => {} };
 
       onChangeSpy = jest.fn();
     });

--- a/src/Components/ArraySubform/index.js
+++ b/src/Components/ArraySubform/index.js
@@ -31,6 +31,7 @@ export default class ArraySubform extends React.Component {
     return (
       <div className="subform">
         <Form
+          key={`${this.props.selectedIndex}_${this.props.selectedFormSection}`}
           fields={this.props.fields}
           formData={this.formData()}
           schema={this.schema()}


### PR DESCRIPTION
WHAT
- Adds a key to the form component within the array subform

WHY
- Forms were being populated with old data when passed in formData which was the same shape as another tab due to the lack of key to uniquely identify each form