### PR TITLE
Return component

### DIFF
--- a/src/Components/ReturnList/index.js
+++ b/src/Components/ReturnList/index.js
@@ -3,25 +3,27 @@ import React from "react";
 export default class ReturnList extends React.Component {
   constructor(props) {
     super(props);
+  }
 
-    this.state = {
-      id: this.props.formData.id,
-      project_id: this.props.formData.project_id,
-      status: this.props.formData.status,
-      updates: this.props.formData.updates
-    };
+  renderListItems() {
+    console.log(this.props.formData.returns[0])
+    return (
+      <div>
+        <a className="list-group-item" data-test={`return-${this.props.formData.returns[0].id}`}>
+          Return {this.props.formData.returns[0].id}
+        </a>
+      </div>
+    );
   }
 
   render() {
     return (
       <div className="panel panel-default">
-        <div className="panel-heading" data-test="schema-title">{this.props.schema.title}</div>
+        <div className="panel-heading" data-test="schema-title">
+          {this.props.schema.title}
+        </div>
         <div className="panel-body">
-          <ul className="list-group">
-            <a className="list-group-item">Return 1</a>
-            <a className="list-group-item">Return 2</a>
-            <a className="list-group-item">Return 3</a>
-          </ul>
+          <ul className="list-group">{this.renderListItems()}</ul>
         </div>
       </div>
     );

--- a/src/Components/ReturnList/index.js
+++ b/src/Components/ReturnList/index.js
@@ -6,14 +6,17 @@ export default class ReturnList extends React.Component {
   }
 
   renderListItems() {
-    console.log(this.props.formData.returns[0])
-    return (
-      <div>
-        <a className="list-group-item" data-test={`return-${this.props.formData.returns[0].id}`}>
-          Return {this.props.formData.returns[0].id}
-        </a>
-      </div>
-    );
+    const returns = this.props.formData.returns;
+    const listItems = returns.map(returns => (
+      <a
+        key={returns.id.toString()}
+        className="list-group-item"
+        data-test={`return-${returns.id}`}
+      >
+        Return {returns.id}
+      </a>
+    ));
+    return listItems;
   }
 
   render() {

--- a/src/Components/ReturnList/index.js
+++ b/src/Components/ReturnList/index.js
@@ -6,10 +6,13 @@ export default class ReturnList extends React.Component {
   }
 
   renderListItems() {
+    const url = window.location.origin;
     const returns = this.props.formData.returns;
+    console.log(url);
     const listItems = returns.map(returns => (
       <a
         key={returns.id.toString()}
+        href={`${url}/project/${returns.project_id}`}
         className="list-group-item"
         data-test={`return-${returns.id}`}
       >

--- a/src/Components/ReturnList/index.js
+++ b/src/Components/ReturnList/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import "./style.css";
 
 export default class ReturnList extends React.Component {
   constructor(props) {
@@ -8,16 +9,23 @@ export default class ReturnList extends React.Component {
   renderListItems() {
     const url = window.location.origin;
     const returns = this.props.formData.returns;
-    console.log(url);
     const listItems = returns.map(returns => (
-      <a
-        key={returns.id.toString()}
-        href={`${url}/project/${returns.project_id}`}
-        className="list-group-item"
-        data-test={`return-${returns.id}`}
-      >
-        Return {returns.id}
-      </a>
+      <div className="row" key={returns.id.toString()}>
+        <div className="col-md-10">
+          <a
+            href={`${url}/project/${returns.project_id}/return/${returns.id}`}
+            className="list-group-item"
+            data-test={`return-${returns.id}`}
+          >
+            Return {returns.id}
+          </a>
+        </div>
+        <div className="col-md-2 return-list">
+          <strong className="beta" data-test={`status-${returns.id}`}>
+            {returns.status}
+          </strong>
+        </div>
+      </div>
     ));
     return listItems;
   }

--- a/src/Components/ReturnList/index.js
+++ b/src/Components/ReturnList/index.js
@@ -1,0 +1,29 @@
+import React from "react";
+
+export default class ReturnList extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      id: this.props.formData.id,
+      project_id: this.props.formData.project_id,
+      status: this.props.formData.status,
+      updates: this.props.formData.updates
+    };
+  }
+
+  render() {
+    return (
+      <div className="panel panel-default">
+        <div className="panel-heading" data-test="schema-title">{this.props.schema.title}</div>
+        <div className="panel-body">
+          <ul className="list-group">
+            <a className="list-group-item">Return 1</a>
+            <a className="list-group-item">Return 2</a>
+            <a className="list-group-item">Return 3</a>
+          </ul>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/Components/ReturnList/index.js
+++ b/src/Components/ReturnList/index.js
@@ -6,35 +6,59 @@ export default class ReturnList extends React.Component {
     super(props);
   }
 
-  renderListItems() {
-    const url = window.location.origin;
-    const returns = this.props.formData.returns;
-    const listItems = returns.map(returns => (
-      <div className="row" key={returns.id.toString()}>
-        <div className="col-md-10">
-          <a
-            href={`${url}/project/${returns.project_id}/return/${returns.id}`}
-            className="list-group-item"
-            data-test={`return-${returns.id}`}
-          >
-            Return {returns.id}
-          </a>
-        </div>
-        <div className="col-md-2 return-list">
-          <strong className="beta" data-test={`status-${returns.id}`}>
-            {returns.status}
-          </strong>
-        </div>
+  renderLink(returns) {
+    return (
+      <div className="col-md-10">
+        <a
+          href={`/project/${returns.project_id}/return/${returns.id}`}
+          className="list-group-item"
+          data-test={`return-${returns.id}`}
+        >
+          Return {returns.id}
+        </a>
       </div>
-    ));
-    return listItems;
+    );
+  }
+
+  renderStatus(returns) {
+    let status = returns.status;
+    if (status == "Draft") {
+      return (
+        <span className="badge" data-test={`status-${returns.id}`}>
+          {status}
+        </span>
+      );
+    } else {
+      return (
+        <span
+          className="badge badge-success"
+          data-test={`status-${returns.id}`}
+        >
+          {status}
+        </span>
+      );
+    }
+  }
+
+  renderReturn(returns) {
+    return (
+      <div className="row padding-bottom" key={returns.id.toString()}>
+        <div className="col-md-10">{this.renderLink(returns)}</div>
+        <div className="col-md-2 return-list">{this.renderStatus(returns)}</div>
+      </div>
+    );
+  }
+
+  renderListItems() {
+    const returns = this.props.formData.returns;
+    return returns.map(returns => this.renderReturn(returns));
   }
 
   render() {
     return (
       <div className="panel panel-default">
         <div className="panel-heading" data-test="schema-title">
-          {this.props.schema.title}
+          Returns: {this.props.schema.title}
         </div>
         <div className="panel-body">
           <ul className="list-group">{this.renderListItems()}</ul>

--- a/src/Components/ReturnList/index.js
+++ b/src/Components/ReturnList/index.js
@@ -8,15 +8,14 @@ export default class ReturnList extends React.Component {
 
   renderLink(returns) {
     return (
-      <div className="col-md-10">
-        <a
-          href={`/project/${returns.project_id}/return/${returns.id}`}
-          className="list-group-item"
-          data-test={`return-${returns.id}`}
-        >
-          Return {returns.id}
-        </a>
-      </div>
+      <a
+        href={`/project/${returns.project_id}/return/${returns.id}`}
+        className="list-group-item"
+        data-test={`url-${returns.id}`}
+      >
+          <div data-test={`return-${returns.id}`}>Return {returns.id}</div>
+          <div className="pull-right">{this.renderStatus(returns)}</div>
+      </a>
     );
   }
 
@@ -42,9 +41,8 @@ export default class ReturnList extends React.Component {
 
   renderReturn(returns) {
     return (
-      <div className="row padding-bottom" key={returns.id.toString()}>
-        <div className="col-md-10">{this.renderLink(returns)}</div>
-        <div className="col-md-2 return-list">{this.renderStatus(returns)}</div>
+      <div className="row padding" key={returns.id.toString()}>
+        {this.renderLink(returns)}
       </div>
     );
   }

--- a/src/Components/ReturnList/returnList.test.js
+++ b/src/Components/ReturnList/returnList.test.js
@@ -17,6 +17,7 @@ class ReturnListComponent {
   listItem5 = () => this.returnList.find("[data-test='return-5']").text();
   listItem6 = () => this.returnList.find("[data-test='return-6']").text();
   listItem7 = () => this.returnList.find("[data-test='return-7']").text();
+  urlTarget = () => this.returnList.find("[data-test='return-1']").prop("href");
 }
 
 describe("<ReturnList", () => {
@@ -45,6 +46,10 @@ describe("<ReturnList", () => {
 
       it("displays a list item for the return", () => {
         expect(returnList.listItem1()).toEqual("Return 1");
+      });
+
+      it("creates a link to the correct location", () => {
+        expect(returnList.urlTarget()).toEqual("http://localhost/project/1");
       });
     });
 

--- a/src/Components/ReturnList/returnList.test.js
+++ b/src/Components/ReturnList/returnList.test.js
@@ -10,10 +10,73 @@ class ReturnListComponent {
   }
 
   title = () => this.returnList.find("[data-test='schema-title']").text();
+  listItem1 = () => this.returnList.find("[data-test='return-1']").text();
+  listItem2 = () => this.returnList.find("[data-test='return-2']").text();
+  listItem3 = () => this.returnList.find("[data-test='return-3']").text();
+  listItem4 = () => this.returnList.find("[data-test='return-5']").text();
+  listItem5 = () => this.returnList.find("[data-test='return-5']").text();
+  listItem6 = () => this.returnList.find("[data-test='return-6']").text();
+  listItem7 = () => this.returnList.find("[data-test='return-7']").text();
 }
 
 describe("<ReturnList", () => {
   describe("Given one return", () => {
+    describe("Example 1", () => {
+      let formData = {
+        returns: [
+          {
+            id: "1",
+            project_id: "1",
+            status: "Draft",
+            updates: [
+              {
+                changes: "Yes"
+              }
+            ]
+          }
+        ]
+      };
+      let schemaTitle = "Returns";
+      let returnList = new ReturnListComponent(formData, schemaTitle);
+
+      it("displays this schema title", () => {
+        expect(returnList.title()).toEqual("Returns");
+      });
+
+      it("displays a list item for the return", () => {
+        expect(returnList.listItem1()).toEqual("Return 1");
+      });
+    });
+
+    describe("Example 2", () => {
+      let formData = {
+        returns: [
+          {
+            id: "7",
+            project_id: "1",
+            status: "Saved",
+            updates: [
+              {
+                changes: "Some"
+              }
+            ]
+          }
+        ]
+      };
+      let schemaTitle = "List of Returns";
+      let returnList = new ReturnListComponent(formData, schemaTitle);
+
+      it("displays this schema title", () => {
+        expect(returnList.title()).toEqual("List of Returns");
+      });
+
+      it("displays a list item for the return", () => {
+        expect(returnList.listItem7()).toEqual("Return 7");
+      });
+    });
+  });
+
+  xdescribe("Given two returns", () => {
     describe("Example 1", () => {
       let formData = {
         returns: {
@@ -21,6 +84,12 @@ describe("<ReturnList", () => {
           project_id: "1",
           status: "Draft",
           updates: "Yes"
+        },
+        returns: {
+          id: "2",
+          project_id: "1",
+          status: "Saved",
+          update: "Some"
         }
       };
       let schemaTitle = "Returns";
@@ -28,6 +97,10 @@ describe("<ReturnList", () => {
 
       it("displays this schema title", () => {
         expect(returnList.title()).toEqual("Returns");
+      });
+
+      it("displays a list item for the return", () => {
+        expect(returnList.listItem1()).toEqual("Return 1");
       });
     });
   });

--- a/src/Components/ReturnList/returnList.test.js
+++ b/src/Components/ReturnList/returnList.test.js
@@ -1,0 +1,34 @@
+import ReturnList from ".";
+import React from "react";
+import { shallow } from "enzyme";
+
+class ReturnListComponent {
+  constructor(formData, schemaTitle) {
+    this.returnList = shallow(
+      <ReturnList schema={{ title: schemaTitle }} formData={formData} />
+    );
+  }
+
+  title = () => this.returnList.find("[data-test='schema-title']").text();
+}
+
+describe("<ReturnList", () => {
+  describe("Given one return", () => {
+    describe("Example 1", () => {
+      let formData = {
+        returns: {
+          id: "1",
+          project_id: "1",
+          status: "Draft",
+          updates: "Yes"
+        }
+      };
+      let schemaTitle = "Returns";
+      let returnList = new ReturnListComponent(formData, schemaTitle);
+
+      it("displays this schema title", () => {
+        expect(returnList.title()).toEqual("Returns");
+      });
+    });
+  });
+});

--- a/src/Components/ReturnList/returnList.test.js
+++ b/src/Components/ReturnList/returnList.test.js
@@ -76,21 +76,31 @@ describe("<ReturnList", () => {
     });
   });
 
-  xdescribe("Given two returns", () => {
+  describe("Given two returns", () => {
     describe("Example 1", () => {
       let formData = {
-        returns: {
-          id: "1",
-          project_id: "1",
-          status: "Draft",
-          updates: "Yes"
-        },
-        returns: {
-          id: "2",
-          project_id: "1",
-          status: "Saved",
-          update: "Some"
-        }
+        returns: [
+          {
+            id: "1",
+            project_id: "1",
+            status: "Draft",
+            updates: [
+              {
+                changes: "Yes"
+              }
+            ]
+          },
+          {
+            id: "2",
+            project_id: "1",
+            status: "Saved",
+            update: [
+              {
+                changes: "Some"
+              }
+            ]
+          }
+        ]
       };
       let schemaTitle = "Returns";
       let returnList = new ReturnListComponent(formData, schemaTitle);
@@ -99,8 +109,47 @@ describe("<ReturnList", () => {
         expect(returnList.title()).toEqual("Returns");
       });
 
-      it("displays a list item for the return", () => {
+      it("displays multiple list items for the returns", () => {
         expect(returnList.listItem1()).toEqual("Return 1");
+        expect(returnList.listItem2()).toEqual("Return 2");
+      });
+    });
+
+    describe("Example 2", () => {
+      let formData = {
+        returns: [
+          {
+            id: "7",
+            project_id: "1",
+            status: "Saved",
+            updates: [
+              {
+                changes: "Some"
+              }
+            ]
+          },
+          {
+            id: "6",
+            project_id: "1",
+            status: "Woof",
+            update: [
+              {
+                changes: "Meow"
+              }
+            ]
+          }
+        ]
+      };
+      let schemaTitle = "Returns";
+      let returnList = new ReturnListComponent(formData, schemaTitle);
+
+      it("displays this schema title", () => {
+        expect(returnList.title()).toEqual("Returns");
+      });
+
+      it("displays multiple list items for the returns", () => {
+        expect(returnList.listItem7()).toEqual("Return 7");
+        expect(returnList.listItem6()).toEqual("Return 6");
       });
     });
   });

--- a/src/Components/ReturnList/returnList.test.js
+++ b/src/Components/ReturnList/returnList.test.js
@@ -8,16 +8,13 @@ class ReturnListComponent {
       <ReturnList schema={{ title: schemaTitle }} formData={formData} />
     );
   }
-
   title = () => this.returnList.find("[data-test='schema-title']").text();
-  listItem1 = () => this.returnList.find("[data-test='return-1']").text();
-  listItem2 = () => this.returnList.find("[data-test='return-2']").text();
-  listItem3 = () => this.returnList.find("[data-test='return-3']").text();
-  listItem4 = () => this.returnList.find("[data-test='return-5']").text();
-  listItem5 = () => this.returnList.find("[data-test='return-5']").text();
-  listItem6 = () => this.returnList.find("[data-test='return-6']").text();
-  listItem7 = () => this.returnList.find("[data-test='return-7']").text();
-  urlTarget = () => this.returnList.find("[data-test='return-1']").prop("href");
+  listItem = number =>
+    this.returnList.find(`[data-test='return-${number}']`).text();
+  status = number =>
+    this.returnList.find(`[data-test='status-${number}']`).text();
+  urlTarget = number =>
+    this.returnList.find(`[data-test='return-${number}']`).prop("href");
 }
 
 describe("<ReturnList", () => {
@@ -39,17 +36,22 @@ describe("<ReturnList", () => {
       };
       let schemaTitle = "Returns";
       let returnList = new ReturnListComponent(formData, schemaTitle);
+      let url = window.location.origin;
 
       it("displays this schema title", () => {
         expect(returnList.title()).toEqual("Returns");
       });
 
       it("displays a list item for the return", () => {
-        expect(returnList.listItem1()).toEqual("Return 1");
+        expect(returnList.listItem(1)).toEqual("Return 1");
       });
 
       it("creates a link to the correct location", () => {
-        expect(returnList.urlTarget()).toEqual("http://localhost/project/1");
+        expect(returnList.urlTarget(1)).toEqual(`${url}/project/1/return/1`);
+      });
+
+      it("shows the current status of the return", () => {
+        expect(returnList.status(1)).toEqual("Draft");
       });
     });
 
@@ -70,13 +72,22 @@ describe("<ReturnList", () => {
       };
       let schemaTitle = "List of Returns";
       let returnList = new ReturnListComponent(formData, schemaTitle);
+      let url = window.location.origin;
 
       it("displays this schema title", () => {
         expect(returnList.title()).toEqual("List of Returns");
       });
 
       it("displays a list item for the return", () => {
-        expect(returnList.listItem7()).toEqual("Return 7");
+        expect(returnList.listItem(7)).toEqual("Return 7");
+      });
+
+      it("creates a link to the correct location", () => {
+        expect(returnList.urlTarget(7)).toEqual(`${url}/project/1/return/7`);
+      });
+
+      it("shows the current status of the return", () => {
+        expect(returnList.status(7)).toEqual("Saved");
       });
     });
   });
@@ -109,14 +120,25 @@ describe("<ReturnList", () => {
       };
       let schemaTitle = "Returns";
       let returnList = new ReturnListComponent(formData, schemaTitle);
+      let url = window.location.origin;
 
       it("displays this schema title", () => {
         expect(returnList.title()).toEqual("Returns");
       });
 
       it("displays multiple list items for the returns", () => {
-        expect(returnList.listItem1()).toEqual("Return 1");
-        expect(returnList.listItem2()).toEqual("Return 2");
+        expect(returnList.listItem(1)).toEqual("Return 1");
+        expect(returnList.listItem(2)).toEqual("Return 2");
+      });
+
+      it("creates a link to the correct location", () => {
+        expect(returnList.urlTarget(1)).toEqual(`${url}/project/1/return/1`);
+        expect(returnList.urlTarget(2)).toEqual(`${url}/project/1/return/2`);
+      });
+
+      it("shows the current status of the return", () => {
+        expect(returnList.status(1)).toEqual("Draft");
+        expect(returnList.status(2)).toEqual("Saved");
       });
     });
 
@@ -147,14 +169,25 @@ describe("<ReturnList", () => {
       };
       let schemaTitle = "Returns";
       let returnList = new ReturnListComponent(formData, schemaTitle);
+      let url = window.location.origin;
 
       it("displays this schema title", () => {
         expect(returnList.title()).toEqual("Returns");
       });
 
       it("displays multiple list items for the returns", () => {
-        expect(returnList.listItem7()).toEqual("Return 7");
-        expect(returnList.listItem6()).toEqual("Return 6");
+        expect(returnList.listItem(7)).toEqual("Return 7");
+        expect(returnList.listItem(6)).toEqual("Return 6");
+      });
+
+      it("creates a link to the correct location", () => {
+        expect(returnList.urlTarget(7)).toEqual(`${url}/project/1/return/7`);
+        expect(returnList.urlTarget(6)).toEqual(`${url}/project/1/return/6`);
+      });
+
+      it("shows the current status of the return", () => {
+        expect(returnList.status(7)).toEqual("Saved");
+        expect(returnList.status(6)).toEqual("Woof");
       });
     });
   });

--- a/src/Components/ReturnList/returnList.test.js
+++ b/src/Components/ReturnList/returnList.test.js
@@ -34,12 +34,12 @@ describe("<ReturnList", () => {
           }
         ]
       };
-      let schemaTitle = "Returns";
+      let schemaTitle = "Cat Housing";
       let returnList = new ReturnListComponent(formData, schemaTitle);
       let url = window.location.origin;
 
       it("displays this schema title", () => {
-        expect(returnList.title()).toEqual("Returns");
+        expect(returnList.title()).toEqual("Returns: Cat Housing");
       });
 
       it("displays a list item for the return", () => {
@@ -47,7 +47,7 @@ describe("<ReturnList", () => {
       });
 
       it("creates a link to the correct location", () => {
-        expect(returnList.urlTarget(1)).toEqual(`${url}/project/1/return/1`);
+        expect(returnList.urlTarget(1)).toEqual("/project/1/return/1");
       });
 
       it("shows the current status of the return", () => {
@@ -70,12 +70,12 @@ describe("<ReturnList", () => {
           }
         ]
       };
-      let schemaTitle = "List of Returns";
+      let schemaTitle = "Dog Kennels";
       let returnList = new ReturnListComponent(formData, schemaTitle);
       let url = window.location.origin;
 
       it("displays this schema title", () => {
-        expect(returnList.title()).toEqual("List of Returns");
+        expect(returnList.title()).toEqual("Returns: Dog Kennels");
       });
 
       it("displays a list item for the return", () => {
@@ -83,7 +83,7 @@ describe("<ReturnList", () => {
       });
 
       it("creates a link to the correct location", () => {
-        expect(returnList.urlTarget(7)).toEqual(`${url}/project/1/return/7`);
+        expect(returnList.urlTarget(7)).toEqual("/project/1/return/7");
       });
 
       it("shows the current status of the return", () => {
@@ -118,12 +118,12 @@ describe("<ReturnList", () => {
           }
         ]
       };
-      let schemaTitle = "Returns";
+      let schemaTitle = "Cat Housing";
       let returnList = new ReturnListComponent(formData, schemaTitle);
       let url = window.location.origin;
 
       it("displays this schema title", () => {
-        expect(returnList.title()).toEqual("Returns");
+        expect(returnList.title()).toEqual("Returns: Cat Housing");
       });
 
       it("displays multiple list items for the returns", () => {
@@ -132,8 +132,8 @@ describe("<ReturnList", () => {
       });
 
       it("creates a link to the correct location", () => {
-        expect(returnList.urlTarget(1)).toEqual(`${url}/project/1/return/1`);
-        expect(returnList.urlTarget(2)).toEqual(`${url}/project/1/return/2`);
+        expect(returnList.urlTarget(1)).toEqual("/project/1/return/1");
+        expect(returnList.urlTarget(2)).toEqual("/project/1/return/2");
       });
 
       it("shows the current status of the return", () => {
@@ -167,12 +167,12 @@ describe("<ReturnList", () => {
           }
         ]
       };
-      let schemaTitle = "Returns";
+      let schemaTitle = "Dog Kennels";
       let returnList = new ReturnListComponent(formData, schemaTitle);
       let url = window.location.origin;
 
       it("displays this schema title", () => {
-        expect(returnList.title()).toEqual("Returns");
+        expect(returnList.title()).toEqual("Returns: Dog Kennels");
       });
 
       it("displays multiple list items for the returns", () => {
@@ -181,8 +181,8 @@ describe("<ReturnList", () => {
       });
 
       it("creates a link to the correct location", () => {
-        expect(returnList.urlTarget(7)).toEqual(`${url}/project/1/return/7`);
-        expect(returnList.urlTarget(6)).toEqual(`${url}/project/1/return/6`);
+        expect(returnList.urlTarget(7)).toEqual("/project/1/return/7");
+        expect(returnList.urlTarget(6)).toEqual("/project/1/return/6");
       });
 
       it("shows the current status of the return", () => {

--- a/src/Components/ReturnList/returnList.test.js
+++ b/src/Components/ReturnList/returnList.test.js
@@ -14,7 +14,7 @@ class ReturnListComponent {
   status = number =>
     this.returnList.find(`[data-test='status-${number}']`).text();
   urlTarget = number =>
-    this.returnList.find(`[data-test='return-${number}']`).prop("href");
+    this.returnList.find(`[data-test='url-${number}']`).prop("href");
 }
 
 describe("<ReturnList", () => {

--- a/src/Components/ReturnList/stories.js
+++ b/src/Components/ReturnList/stories.js
@@ -2,16 +2,52 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import ReturnList from ".";
 
-storiesOf("ReturnList", module).add("default", () => (
-  <ReturnList
-    schema={{ title: "Returns" }}
-    formData={{
-      returns: {
-        id: "1",
-        project_id: "1",
-        status: "Draft",
-        updates: "Yes"
-      }
-    }}
-  />
-));
+storiesOf("ReturnList", module)
+  .add("default", () => (
+    <ReturnList
+      schema={{ title: "Returns" }}
+      formData={{
+        returns: [
+          {
+            id: "1",
+            project_id: "1",
+            status: "Draft",
+            updates: [
+              {
+                changed: "Yes"
+              }
+            ]
+          }
+        ]
+      }}
+    />
+  ))
+  .add("multiple returns", () => (
+    <ReturnList
+      schema={{ title: "Returns" }}
+      formData={{
+        returns: [
+          {
+            id: "1",
+            project_id: "1",
+            status: "Draft",
+            updates: [
+              {
+                changed: "Yes"
+              }
+            ]
+          },
+          {
+            id: "2",
+            project_id: "1",
+            status: "Saved",
+            updates: [
+              {
+                changed: "Some"
+              }
+            ]
+          }
+        ]
+      }}
+    />
+  ));

--- a/src/Components/ReturnList/stories.js
+++ b/src/Components/ReturnList/stories.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import ReturnList from ".";
+
+storiesOf("ReturnList", module).add("default", () => (
+  <ReturnList
+    schema={{ title: "Returns" }}
+    formData={{
+      returns: {
+        id: "1",
+        project_id: "1",
+        status: "Draft",
+        updates: "Yes"
+      }
+    }}
+  />
+));

--- a/src/Components/ReturnList/stories.js
+++ b/src/Components/ReturnList/stories.js
@@ -5,7 +5,7 @@ import ReturnList from ".";
 storiesOf("ReturnList", module)
   .add("default", () => (
     <ReturnList
-      schema={{ title: "Returns" }}
+      schema={{ title: "Cat Housing" }}
       formData={{
         returns: [
           {
@@ -24,7 +24,7 @@ storiesOf("ReturnList", module)
   ))
   .add("multiple returns", () => (
     <ReturnList
-      schema={{ title: "Returns" }}
+      schema={{ title: "Dog Kennels" }}
       formData={{
         returns: [
           {

--- a/src/Components/ReturnList/stories.js
+++ b/src/Components/ReturnList/stories.js
@@ -24,7 +24,7 @@ storiesOf("ReturnList", module)
   ))
   .add("multiple returns", () => (
     <ReturnList
-      schema={{ title: "Dog Kennels" }}
+      schema={{ title: "Kittens Housing Association" }}
       formData={{
         returns: [
           {
@@ -40,7 +40,7 @@ storiesOf("ReturnList", module)
           {
             id: "2",
             project_id: "1",
-            status: "Saved",
+            status: "Submitted",
             updates: [
               {
                 changed: "Some"

--- a/src/Components/ReturnList/style.css
+++ b/src/Components/ReturnList/style.css
@@ -1,0 +1,3 @@
+.return-list {
+  line-height: 42px;
+}

--- a/src/Components/ReturnList/style.css
+++ b/src/Components/ReturnList/style.css
@@ -1,3 +1,12 @@
 .return-list {
   line-height: 42px;
 }
+
+.badge-success {
+  color: #fff;
+  background-color: #28a745;
+}
+
+.padding-bottom {
+  padding-bottom: 1em;
+}

--- a/src/Components/ReturnList/style.css
+++ b/src/Components/ReturnList/style.css
@@ -7,6 +7,8 @@
   background-color: #28a745;
 }
 
-.padding-bottom {
+.padding {
   padding-bottom: 1em;
+  padding-left: 1em;
+  padding-right: 1em;
 }


### PR DESCRIPTION
WHAT:
<img width="1038" alt="screenshot 2018-10-04 at 10 29 34" src="https://user-images.githubusercontent.com/20663545/46465421-737cb100-c7c0-11e8-9b2a-344291f45e08.png">
New component for displaying links to all returns related to a project.

WHY:
Clients currently need to remember/store the URL of the returns they're working on.