### PR TITLE
Correct placement of status badge

### DIFF
--- a/src/Components/ReturnList/index.js
+++ b/src/Components/ReturnList/index.js
@@ -13,7 +13,7 @@ export default class ReturnList extends React.Component {
         className="list-group-item"
         data-test={`url-${returns.id}`}
       >
-          <div data-test={`return-${returns.id}`}>Return {returns.id}</div>
+          <span data-test={`return-${returns.id}`}>Return {returns.id}</span>
           <div className="pull-right">{this.renderStatus(returns)}</div>
       </a>
     );


### PR DESCRIPTION
WHY:
Previous commit to correct failing test moved an element out of line with where it should be.
This PR moves it back to the correct position.

BEFORE:
<img width="1038" alt="screenshot 2018-10-04 at 11 32 50" src="https://user-images.githubusercontent.com/20663545/46468743-3f59be00-c7c9-11e8-9716-0a66cabbfa12.png">

AFTER:
<img width="1036" alt="screenshot 2018-10-04 at 11 32 07" src="https://user-images.githubusercontent.com/20663545/46468713-2a7d2a80-c7c9-11e8-9ee1-b244a0996dc0.png">