### PR TITLE
Extend field type support in horizontal fields

### DIFF
--- a/src/Components/HorizontalFields/horizontalFields.test.js
+++ b/src/Components/HorizontalFields/horizontalFields.test.js
@@ -251,7 +251,7 @@ describe("<HorizontalFields>", () => {
     });
   });
 
-  fdescribe("Given a dropdown", () => {
+  describe("Given a dropdown", () => {
     describe("Example one", () => {
       it("Makes the field a dropdown with all the options with the default", () => {
         schema = {
@@ -389,6 +389,34 @@ describe("<HorizontalFields>", () => {
 
         expect(fields.state().woof).toEqual("Puppy");
       });
+    });
+  });
+
+  describe("Given a text input of format date", () => {
+    it("Renders the input as a date field", () => {
+      schema = {
+        title: "Cats",
+        properties: {
+          dog: { type: "string", title: "Dog" },
+          cow: { type: "string", title: "Cow", format: "date" }
+        }
+      };
+
+      formData = {};
+
+      fields = mount(
+        <HorizontalFields
+          schema={schema}
+          formData={formData}
+          onChange={() => {}}
+        />
+      );
+
+      let dogInput = fields.find('[data-test="dog-input"]');
+      let cowInput = fields.find('[data-test="cow-input"]');
+
+      expect(dogInput.props().type).toEqual("text");
+      expect(cowInput.props().type).toEqual("date");
     });
   });
 });

--- a/src/Components/HorizontalFields/horizontalFields.test.js
+++ b/src/Components/HorizontalFields/horizontalFields.test.js
@@ -206,7 +206,7 @@ describe("<HorizontalFields>", () => {
             meow: { type: "text", title: "Meow" },
             woof: { type: "text", title: "Woof" }
           },
-          required: ['meow']
+          required: ["meow"]
         };
         formData = { meow: "Cat noise" };
         onChangeSpy = jest.fn();
@@ -218,10 +218,12 @@ describe("<HorizontalFields>", () => {
           />
         );
 
-        expect(fields.find("[data-test='meow-label']").text()).toEqual("Meow *")
+        expect(fields.find("[data-test='meow-label']").text()).toEqual(
+          "Meow *"
+        );
       });
     });
-    
+
     describe("Example two", () => {
       it("Marks the field as required", () => {
         schema = {
@@ -230,7 +232,7 @@ describe("<HorizontalFields>", () => {
             cow: { type: "text", title: "Cow" },
             chicken: { type: "text", title: "Chicken" }
           },
-          required: ['chicken']
+          required: ["chicken"]
         };
         formData = { meow: "Cat noise" };
         onChangeSpy = jest.fn();
@@ -242,7 +244,150 @@ describe("<HorizontalFields>", () => {
           />
         );
 
-        expect(fields.find("[data-test='chicken-label']").text()).toEqual("Chicken *")
+        expect(fields.find("[data-test='chicken-label']").text()).toEqual(
+          "Chicken *"
+        );
+      });
+    });
+  });
+
+  fdescribe("Given a dropdown", () => {
+    describe("Example one", () => {
+      it("Makes the field a dropdown with all the options with the default", () => {
+        schema = {
+          title: "Cats",
+          properties: {
+            meow: { type: "string", enum: ["Cat", "Kitten"], default: "Cat" }
+          }
+        };
+        fields = mount(
+          <HorizontalFields schema={schema} formData={{}} onChange={() => {}} />
+        );
+
+        let dropdown = fields.find("[data-test='meow-input']");
+        let options = dropdown.children();
+
+        expect(dropdown.children().length).toEqual(2);
+        expect(options.at(0).text()).toEqual("Cat");
+        expect(options.at(1).text()).toEqual("Kitten");
+        expect(dropdown.props().value).toEqual("Cat");
+      });
+
+      it("Makes the field the value given in the form data when present", () => {
+        schema = {
+          title: "Cats",
+          properties: {
+            meow: { type: "string", enum: ["Cat", "Kitten"], default: "Cat" }
+          }
+        };
+        fields = mount(
+          <HorizontalFields
+            schema={schema}
+            formData={{ meow: "Kitten" }}
+            onChange={() => {}}
+          />
+        );
+
+        let dropdown = fields.find("[data-test='meow-input']");
+
+        expect(dropdown.props().value).toEqual("Kitten");
+      });
+
+      it("Updates the state when changing the dropdown", () => {
+        schema = {
+          title: "Cats",
+          properties: {
+            meow: { type: "string", enum: ["Cat", "Kitten"], default: "Cat" }
+          }
+        };
+        fields = mount(
+          <HorizontalFields
+            schema={schema}
+            formData={{ meow: "Kitten" }}
+            onChange={() => {}}
+          />
+        );
+
+        let dropdown = fields.find("[data-test='meow-input']");
+        dropdown.simulate("change", { target: { value: "Cat" } });
+
+        expect(fields.state().meow).toEqual("Cat");
+      });
+    });
+
+    describe("Example two", () => {
+      it("Makes the field a dropdown with all the options with the default", () => {
+        schema = {
+          title: "Dogs",
+          properties: {
+            woof: {
+              type: "string",
+              enum: ["Dog", "Pupper", "Puppy"],
+              default: "Pupper"
+            }
+          }
+        };
+        fields = mount(
+          <HorizontalFields schema={schema} formData={{}} onChange={() => {}} />
+        );
+
+        let dropdown = fields.find("[data-test='woof-input']");
+        let options = dropdown.children();
+
+        expect(dropdown.children().length).toEqual(3);
+        expect(options.at(0).text()).toEqual("Dog");
+        expect(options.at(1).text()).toEqual("Pupper");
+        expect(options.at(2).text()).toEqual("Puppy");
+        expect(dropdown.props().value).toEqual("Pupper");
+      });
+
+      it("Makes the field the value given in the form data when present", () => {
+        schema = {
+          title: "Dogs",
+          properties: {
+            woof: {
+              type: "string",
+              enum: ["Dog", "Pupper", "Puppy"],
+              default: "Pupper"
+            }
+          }
+        };
+        fields = mount(
+          <HorizontalFields
+            schema={schema}
+            formData={{ woof: "Puppy" }}
+            onChange={() => {}}
+          />
+        );
+
+        let dropdown = fields.find("[data-test='woof-input']");
+
+        expect(dropdown.props().value).toEqual("Puppy");
+      });
+
+      it("Updates the state when selecting something in the dropdown", () => {
+        schema = {
+          title: "Dogs",
+          properties: {
+            woof: {
+              type: "string",
+              enum: ["Dog", "Pupper", "Puppy"],
+              default: "Pupper"
+            }
+          }
+        };
+        fields = mount(
+          <HorizontalFields
+            schema={schema}
+            formData={{ woof: "Puppy" }}
+            onChange={() => {}}
+          />
+        );
+
+        let dropdown = fields.find("[data-test='woof-input']");
+        dropdown.simulate("change", { target: { value: "Puppy" } });
+
+        expect(fields.state().woof).toEqual("Puppy");
       });
     });
   });

--- a/src/Components/HorizontalFields/index.js
+++ b/src/Components/HorizontalFields/index.js
@@ -13,10 +13,10 @@ export default class HorizontalFields extends React.Component {
   };
 
   requiredProperty(key) {
-    if(!this.props.schema.required) {
-      return false
+    if (!this.props.schema.required) {
+      return false;
     }
-    return this.props.schema.required.indexOf(key) >= 0
+    return this.props.schema.required.indexOf(key) >= 0;
   }
 
   renderLabel(schemaKey, property) {
@@ -27,7 +27,7 @@ export default class HorizontalFields extends React.Component {
         </label>
       );
     }
-    
+
     return (
       <label htmlFor={schemaKey} data-test={`${schemaKey}-label`}>
         {property.title}
@@ -35,19 +35,41 @@ export default class HorizontalFields extends React.Component {
     );
   }
 
+  renderSelect = (propertyName, schema) => (
+    <select
+      onChange={e => this.onChange(propertyName, e.target.value)}
+      value={this.state[propertyName] || schema.default}
+      data-test={`${propertyName}-input`}
+    >
+      {schema.enum.map(optionValue => (
+        <option key={optionValue}>{optionValue}</option>
+      ))}
+    </select>
+  );
+
+  renderItem = (k, v) => {
+    if (v.type === "string" && v.enum) {
+      return this.renderSelect(k, v)
+    } else {
+      return (
+        <input
+          id={k}
+          disabled={v.readonly}
+          data-test={`${k}-input`}
+          value={this.state[k]}
+          onChange={e => this.onChange(k, e.target.value)}
+        />
+      );
+    }
+  };
+
   renderItems = () =>
     Object.entries(this.props.schema.properties).map(([k, v]) => {
       if (!v.hidden) {
         return (
           <div key={k} data-test="form-field" className="horizontal-item">
             {this.renderLabel(k, v)}
-            <input
-              id={k}
-              disabled={v.readonly}
-              data-test={`${k}-input`}
-              value={this.state[k]}
-              onChange={e => this.onChange(k, e.target.value)}
-            />
+            {this.renderItem(k, v)}
           </div>
         );
       }

--- a/src/Components/HorizontalFields/index.js
+++ b/src/Components/HorizontalFields/index.js
@@ -47,15 +47,24 @@ export default class HorizontalFields extends React.Component {
     </select>
   );
 
+  inputFieldType = schema => {
+    if (schema.format === "date") {
+      return "date";
+    }
+
+    return "text";
+  };
+
   renderItem = (k, v) => {
     if (v.type === "string" && v.enum) {
-      return this.renderSelect(k, v)
+      return this.renderSelect(k, v);
     } else {
       return (
         <input
           id={k}
           disabled={v.readonly}
           data-test={`${k}-input`}
+          type={this.inputFieldType(v)}
           value={this.state[k]}
           onChange={e => this.onChange(k, e.target.value)}
         />


### PR DESCRIPTION
WHAT
- Adds support for date fields in horizontal fields
- Adds support for dropdowns in horizontal fields

WHY
- As we still haven't got fields in place to remove the reliance on horizontal fields, we need to add some extra support for usability