### PR TITLE
Move polyfill imports to index.js rather than baseline component

### DIFF
--- a/src/Components/BaselineData/index.js
+++ b/src/Components/BaselineData/index.js
@@ -1,8 +1,4 @@
 import React from "react";
-import 'core-js/es6/map';
-import 'core-js/es6/array';
-import 'core-js/fn/array/find';
-
 
 export default class BaselineData extends React.Component {
   renderObject = (key, value, propertySchema) => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 import 'core-js/es6/map';
 import 'core-js/es6/symbol';
 import 'core-js/es6/set';
-import 'core-js/es7/object'
+import 'core-js/es7/object';
+import 'core-js/es6/array';
+import 'core-js/fn/array/find';
 import Raven from 'raven-js'
 import ReactGA from 'react-ga';
 import React from 'react';


### PR DESCRIPTION
WHAT:
Move the polyfill imports required to show the baseline data to the index.js file.

WHY:
To prevent issues with the polyfill imports when moving to staging.