### PR TITLE
Implement textarea widget when given extendedText

### DIFF
--- a/src/Components/ReturnForm/style.css
+++ b/src/Components/ReturnForm/style.css
@@ -14,3 +14,14 @@ input:disabled {
   cursor: default !important;
   outline: none !important;
 }
+
+textarea:disabled {
+  background-color: transparent !important;
+  border: 0px !important;
+  box-shadow: none !important;
+  -moz-box-shadow: none !important;
+  -webkit-box-shadow: none !important;
+  color: black;
+  cursor: default !important;
+  outline: none !important;
+}

--- a/src/UseCase/GenerateUISchema/generateUISchema.test.js
+++ b/src/UseCase/GenerateUISchema/generateUISchema.test.js
@@ -685,6 +685,28 @@ describe("GenerateUISchema", () => {
     });
   });
 
+  describe("With extended text fields", () => {
+    describe("In an object", () => {
+      it("Marks the field as a textarea", () => {
+        let schema = {
+          type: "object",
+          properties: {
+            a: {
+              type: "object",
+              properties: {
+                b: { type: "string", extendedText: true }
+              }
+            }
+          }
+        };
+        let response = useCase.execute(schema);
+        expect(response).toEqual({
+          a: { b: { "ui:widget": "textarea" } }
+        });
+      });
+    });
+  });
+
   describe("With hidden fields", () => {
     describe("In an object", () => {
       describe("Example one", () => {
@@ -777,7 +799,7 @@ describe("GenerateUISchema", () => {
       });
 
       describe("When readonly and hidden", () => {
-        it("Marks the field as hidden", () => {
+        it("Marks the field as hidden and readonly", () => {
           let schema = {
             type: "object",
             properties: {
@@ -791,7 +813,7 @@ describe("GenerateUISchema", () => {
           };
           let response = useCase.execute(schema);
           expect(response).toEqual({
-            a: { b: { "ui:widget": "hidden" } }
+            a: { b: { "ui:widget": "hidden", "ui:disabled": true } }
           });
         });
       });

--- a/src/UseCase/GenerateUISchema/index.js
+++ b/src/UseCase/GenerateUISchema/index.js
@@ -67,13 +67,29 @@ export default class GenerateUISchema {
   }
 
   generateSchemaForItem(item) {
-    if (item.hidden) {
-      return { "ui:widget": "hidden" };
-    } else if (item.readonly) {
-      return { "ui:disabled": true };
-    } else if (item.base) {
-      return { "ui:field": "base" };
+    let schema = {}
+
+    if(item.extendedText) {
+      schema["ui:widget"] = "textarea"
     }
+
+    if (item.hidden) {
+      schema["ui:widget"] = "hidden"
+    } 
+
+    if (item.readonly) {
+      schema["ui:disabled"] = true
+    } 
+
+    if (item.base) {
+      schema["ui:field"] = "base"
+    }
+
+    if(Object.keys(schema).length === 0) {
+      return undefined
+    }
+
+    return schema;
   }
 
   isAddableArray(arr) {


### PR DESCRIPTION
![image 2](https://user-images.githubusercontent.com/976254/47091669-36330d00-d21d-11e8-9468-75060ff80cd6.png)

WHAT

Generates uiSchema for extendedText areas

WHY

So we can mark some large areas of text in the schema to be displayed as such without cutting off