### PR TITLE
Change input type for Current return to Date to match output on submit

### DIFF
--- a/src/Components/MilestoneField/index.js
+++ b/src/Components/MilestoneField/index.js
@@ -93,6 +93,7 @@ export default class MilestoneField extends React.Component {
           onChange={e => this.onFieldChange("currentReturn", e)}
           data-test="milestone-current-return"
           value={this.state.currentReturn}
+          type="date"
           id="currentReturn"
         />
       </div>


### PR DESCRIPTION
The input for "Current Return" was just a text field on the draft return.
Changed this to input type of date to resolve the issue where data input on the draft wasn't showing on the submitted return.