### PR TITLE
Use different statuses for updating and submitting.

### DIFF
--- a/src/Components/NewProjectPage/index.js
+++ b/src/Components/NewProjectPage/index.js
@@ -27,7 +27,9 @@ export default class NewProjectPage extends React.Component {
   creationFailure() {}
 
   projectUpdated() {
-    this.setState({ status: "saved" });
+    if(this.state.status === "updating") {
+      this.setState({ status: "saved" });
+    }
   }
 
   projectNotUpdated() {}
@@ -43,7 +45,7 @@ export default class NewProjectPage extends React.Component {
 
   submitProject = async e => {
     this.setState({
-      status: "updating",
+      status: "submitting",
       action: "Submit",
       valid: true,
       prettyInvalidPaths: [[]]
@@ -68,13 +70,12 @@ export default class NewProjectPage extends React.Component {
   };
 
   updateProject = async e => {
-    this.setState({
+    await this.setState({
       status: "updating",
       valid: true,
       action: "Update",
       prettyInvalidPaths: [[]]
     });
-
     if (this.props.status === "LA Draft") {
       await this.validateProject();
     }
@@ -93,6 +94,10 @@ export default class NewProjectPage extends React.Component {
       valid: false
     });
   };
+
+  isLoading() {
+    return this.state.status === "updating" || this.state.status === "submitting"
+  }
 
   renderForm() {
     return (
@@ -117,7 +122,7 @@ export default class NewProjectPage extends React.Component {
   renderSuccessOrForm() {
     if (this.state.status === "submitted") {
       return this.renderSubmitSuccess();
-    } else if (this.state.status === "updating") {
+    } else if (this.isLoading()) {
       return (
         <div>
           <button

--- a/src/Components/NewProjectPage/newProjectPage.test.js
+++ b/src/Components/NewProjectPage/newProjectPage.test.js
@@ -59,9 +59,9 @@ describe("NewProjectPage", () => {
 
   describe("disables buttons while project updating hasnt completed", () => {
     it("example 1", async () => {
-      let submitProjectSpy = { execute: jest.fn(async (presenter, id) => {}) };
+      let submitProjectSpy = { execute: jest.fn(async (presenter, id) => {presenter.creationSuccess(id)}) };
       let updateProjectSpy = {
-        execute: jest.fn(async (presenter, id) => {})
+        execute: jest.fn(async (presenter, id) => {presenter.projectUpdated(id)})
       };
       let validateProjectSpy = { execute: jest.fn(async () => {}) };
 
@@ -272,6 +272,7 @@ describe("NewProjectPage", () => {
       await updateFormField(wrap.find('input[type="text"]'), "hi");
       await wrap.update();
       wrap.find('[data-test="update-project-button"]').simulate("click");
+      await wait();
       expect(validateProjectSpy.execute).toBeCalledWith(
         expect.anything(),
         1,
@@ -308,6 +309,7 @@ describe("NewProjectPage", () => {
       await updateFormField(wrap.find('input[type="text"]'), "Meow");
       await wrap.update();
       wrap.find('[data-test="update-project-button"]').simulate("click");
+      await wait();
       expect(validateProjectSpy.execute).toBeCalledWith(
         expect.anything(),
         6,
@@ -799,8 +801,8 @@ describe("NewProjectPage", () => {
 
       await wait();
       await wrap.find('[data-test="update-project-button"]').simulate("click");
+      await wrap.update()
       await updateFormField(wrap.find('input[type="text"]'), "cashews");
-
       await wrap.update();
       expect(wrap.find('[data-test="project-update-success"]').length).toEqual(
         0


### PR DESCRIPTION
Stops the buttons becoming active after pressing submit and just before the page changes to the submit success page.

They should now stay disabled.

Would be good if someone else could check this out locally as well, because it all happens quite quickly.  