### PR TITLE
Add CSS to stop headers wrapping

### DIFF
--- a/src/Components/QuarterlyBreakdown/style.css
+++ b/src/Components/QuarterlyBreakdown/style.css
@@ -14,5 +14,6 @@
 }
 
 .header {
-  font-weight: 500;
+  font-weight: 700;
+  white-space: nowrap;
 }


### PR DESCRIPTION
Before: 

<img width="628" alt="screen shot 2018-11-06 at 14 21 57" src="https://user-images.githubusercontent.com/38878719/48070281-6728b100-e1cf-11e8-89b5-fd9afcde0bb1.png">
After:
<img width="574" alt="screen shot 2018-11-06 at 14 22 07" src="https://user-images.githubusercontent.com/38878719/48070282-6728b100-e1cf-11e8-9d94-0c57c5140683.png">
