### PR TITLE
Strip empty paths from ValidationMessage

### DIFF
--- a/src/Components/ValidationMessage/index.js
+++ b/src/Components/ValidationMessage/index.js
@@ -3,33 +3,55 @@ import PropTypes from "prop-types";
 
 export default class ValidationMessage extends React.Component {
   renderInvalidPaths = () => {
-    return this.props.invalidPaths.map(path => {
-      return (<span key={path}>
-        {path.join(' → ')}<br/>
-      </span>)
-    })
+    const strippedPaths = this.stripEmptyPaths();
+    return strippedPaths.map(path => {
+      return (
+        <span key={path}>
+          {path.join(" → ")}
+          <br />
+        </span>
+      );
+    });
+  };
+
+  stripEmptyPaths = () => {
+    const strippedPaths = [];
+    this.props.invalidPaths.forEach(element => {
+      strippedPaths.push(element.filter(Boolean));
+    });
+    return strippedPaths;
   };
 
   renderValidation = () => {
     if (this.props.valid) {
       return null;
     }
-    if (this.props.type==="Submit") {
+    if (this.props.type === "Submit") {
       return (
-        <div className="alert alert-danger" role="alert" data-test="validationError">
-          <strong>Error:</strong> This return could not be submitted because the following fields were missing: <br/>
+        <div
+          className="alert alert-danger"
+          role="alert"
+          data-test="validationError"
+        >
+          <strong>Error:</strong> This return could not be submitted because the
+          following fields were missing: <br />
           {this.renderInvalidPaths()}
         </div>
       );
     }
 
     return (
-      <div className="alert alert-warning" role="alert" data-test="validationWarning">
-        <strong>Warning:</strong> You will not be able to submit this return until the following fields are filled in: <br/>
+      <div
+        className="alert alert-warning"
+        role="alert"
+        data-test="validationWarning"
+      >
+        <strong>Warning:</strong> You will not be able to submit this return
+        until the following fields are filled in: <br />
         {this.renderInvalidPaths()}
       </div>
     );
-  }
+  };
 
   render() {
     return this.renderValidation();

--- a/src/Components/ValidationMessage/validationMessage.test.js
+++ b/src/Components/ValidationMessage/validationMessage.test.js
@@ -1,36 +1,106 @@
 import React from "react";
 import ValidationMessage from ".";
-import {mount} from "enzyme";
+import { mount } from "enzyme";
 
 describe("<ValidationMessage>", () => {
-
-  it('is valid', () => {
-    it('example 1', () => {
-      let wrap = mount(<ValidationMessage valid={false} type="Submit" invalidPaths={[["Cats",0,"Cat House"],["Dogs","Dog House"]]}/>)
+  it("is valid", () => {
+    it("example 1", () => {
+      let wrap = mount(
+        <ValidationMessage
+          valid={false}
+          type="Submit"
+          invalidPaths={[["Cats", 0, "Cat House"], ["Dogs", "Dog House"]]}
+        />
+      );
       expect(wrap).toBeNull();
     });
   });
 
-  describe('submission', () => {
-    it('example 1', () => {
-      let wrap = mount(<ValidationMessage valid={false} type="Submit" invalidPaths={[["Cats","Item 1","Cat House"],["Dogs","Dog House"]]}/>)
-      expect(wrap.text()).toEqual("Error: This return could not be submitted because the following fields were missing: Cats → Item 1 → Cat HouseDogs → Dog House");
+  describe("submission", () => {
+    it("example 1", () => {
+      let wrap = mount(
+        <ValidationMessage
+          valid={false}
+          type="Submit"
+          invalidPaths={[
+            ["Cats", "Item 1", "Cat House"],
+            ["Dogs", "Dog House"]
+          ]}
+        />
+      );
+      expect(wrap.text()).toEqual(
+        "Error: This return could not be submitted because the following fields were missing: Cats → Item 1 → Cat HouseDogs → Dog House"
+      );
     });
-    it('example 2', () => {
-      let wrap = mount(<ValidationMessage valid={false} type="Submit" invalidPaths={[["Dogs","Item 2","Breed"],["Cows","Moo"]]}/>)
-      expect(wrap.text()).toEqual("Error: This return could not be submitted because the following fields were missing: Dogs → Item 2 → BreedCows → Moo");
+    it("example 2", () => {
+      let wrap = mount(
+        <ValidationMessage
+          valid={false}
+          type="Submit"
+          invalidPaths={[["Dogs", "Item 2", "Breed"], ["Cows", "Moo"]]}
+        />
+      );
+      expect(wrap.text()).toEqual(
+        "Error: This return could not be submitted because the following fields were missing: Dogs → Item 2 → BreedCows → Moo"
+      );
     });
   });
 
-  describe('save draft', () => {
-    it('example 1', () => {
-      let wrap = mount(<ValidationMessage valid={false} type="Save" invalidPaths={[["Cats","Item 1","Cat House"],["Dogs","Dog House"]]}/>)
-      expect(wrap.text()).toEqual("Warning: You will not be able to submit this return until the following fields are filled in: Cats → Item 1 → Cat HouseDogs → Dog House");
+  describe("save draft", () => {
+    it("example 1", () => {
+      let wrap = mount(
+        <ValidationMessage
+          valid={false}
+          type="Save"
+          invalidPaths={[
+            ["Cats", "Item 1", "Cat House"],
+            ["Dogs", "Dog House"]
+          ]}
+        />
+      );
+      expect(wrap.text()).toEqual(
+        "Warning: You will not be able to submit this return until the following fields are filled in: Cats → Item 1 → Cat HouseDogs → Dog House"
+      );
     });
-    it('example 2', () => {
-      let wrap = mount(<ValidationMessage valid={false} type="Save" invalidPaths={[["Dogs","Item 2","Breed"],["Cows","Moo"]]}/>)
-      expect(wrap.text()).toEqual("Warning: You will not be able to submit this return until the following fields are filled in: Dogs → Item 2 → BreedCows → Moo");
+    it("example 2", () => {
+      let wrap = mount(
+        <ValidationMessage
+          valid={false}
+          type="Save"
+          invalidPaths={[["Dogs", "Item 2", "Breed"], ["Cows", "Moo"]]}
+        />
+      );
+      expect(wrap.text()).toEqual(
+        "Warning: You will not be able to submit this return until the following fields are filled in: Dogs → Item 2 → BreedCows → Moo"
+      );
     });
   });
 
+  describe("empty titles", () => {
+    it("example 1", () => {
+      let wrap = mount(
+        <ValidationMessage
+          valid={false}
+          type="Save"
+          invalidPaths={[["Cats", "", "Cat House"], ["Dogs", "Dog House"]]}
+        />
+      );
+      expect(wrap.text()).toEqual(
+        "Warning: You will not be able to submit this return until the following fields are filled in: Cats → Cat HouseDogs → Dog House"
+      );
+    });
+
+    it("example 2", () => {
+      let wrap = mount(
+        <ValidationMessage
+          valid={false}
+          type="Save"
+          invalidPaths={[["Dogs", "Breed"], ["Cows", "", "Moo"]]}
+        />
+      );
+      expect(wrap.text()).toEqual(
+        "Warning: You will not be able to submit this return until the following fields are filled in: Dogs → BreedCows → Moo"
+      );
+    });
+  });
 });


### PR DESCRIPTION
Checks for empty strings in the path arrays and strips them out before creating the message