### PR TITLE
Support extendedText widgets in HorizontalFields

### DIFF
--- a/src/Components/HorizontalFields/horizontalFields.test.js
+++ b/src/Components/HorizontalFields/horizontalFields.test.js
@@ -1,9 +1,157 @@
 import HorizontalFields from ".";
 import React from "react";
+import WidgetStub from "../../../test/WidgetStub";
 import { mount } from "enzyme";
 
+class CurrencyStub extends WidgetStub { datatest = "currency-stub"; }
+class SecondCurrencyStub extends WidgetStub { datatest = "second-currency-stub"; }
+
 describe("<HorizontalFields>", () => {
-  let schema, fields, formData, onChangeSpy;
+  let schema, fields, formData, onChangeSpy, registrySpy;
+
+  describe("Given a currency widget", () => {
+    describe("Example 1", () => {
+      beforeEach(() => {
+        registrySpy = {
+          widgets: {
+            currency: CurrencyStub
+          }
+        }
+        schema = {
+          title: "Cats",
+          properties: {
+            nyan: { currency: true, type: "text", title: "Nyan" }
+          }
+        };
+        formData = { nyan: "Other cat noises" };
+        onChangeSpy = jest.fn();
+        fields = mount(
+          <HorizontalFields
+            registry={registrySpy}
+            schema={schema}
+            formData={formData}
+            onChange={onChangeSpy}
+          />
+        );
+      });
+
+      it("Renders the currency component from the registry", () => {
+        expect(fields.find("[data-test='currency-stub']").length).toEqual(1);
+      });
+
+      it("Calls the onChange method passed in with the form data", () => {
+        fields
+          .find("input[data-test='currency-stub']")
+          .simulate("change", { target: { value: "New Meow" } });
+
+        expect(onChangeSpy).toHaveBeenCalledWith({ nyan: "New Meow" });
+      });
+    });
+
+    describe("Example 2", () => {
+      beforeEach(() => {
+        registrySpy = {
+          widgets: {
+            currency: SecondCurrencyStub
+          }
+        }
+        schema = {
+          title: "Cats",
+          properties: {
+            meow: { currency: true, type: "text", title: "Many meows" }
+          }
+        };
+        formData = { meow: "Additional cat noises" };
+        onChangeSpy = jest.fn();
+        fields = mount(
+          <HorizontalFields
+            registry={registrySpy}
+            schema={schema}
+            formData={formData}
+            onChange={onChangeSpy}
+          />
+        );
+      });
+
+      it("Renders the currency component from the registry", () => {
+        expect(fields.find("[data-test='second-currency-stub']").length).toEqual(1);
+      });
+
+      it("Calls the onChange method passed in with the form data", () => {
+        fields
+          .find("input[data-test='second-currency-stub']")
+          .simulate("change", { target: { value: "Another Meow" } });
+
+        expect(onChangeSpy).toHaveBeenCalledWith({ meow: "Another Meow" });
+      });
+    });
+  });
+
+  describe("Given an extendedText widget", () => {
+    describe("Example 1", () => {
+      beforeEach(() => {
+        schema = {
+          title: "Cats",
+          properties: {
+            nyan: { extendedText: true, type: "text", title: "Nyan" }
+          }
+        };
+        formData = { nyan: "Other cat noises" };
+        onChangeSpy = jest.fn();
+        fields = mount(
+          <HorizontalFields
+            schema={schema}
+            formData={formData}
+            onChange={onChangeSpy}
+          />
+        );
+      });
+
+      it("Renders the currency component from the registry", () => {
+        expect(fields.find("textarea").length).toEqual(1);
+      });
+
+      it("Calls the onChange method passed in with the form data", () => {
+        fields
+          .find("textarea")
+          .simulate("change", { target: { value: "New Meow" } });
+
+        expect(onChangeSpy).toHaveBeenCalledWith({ nyan: "New Meow" });
+      });
+    });
+
+    describe("Example 2", () => {
+      beforeEach(() => {
+        schema = {
+          title: "Cats",
+          properties: {
+            meow: { extendedText: true, type: "text", title: "Many meows" }
+          }
+        };
+        formData = { meow: "Additional cat noises" };
+        onChangeSpy = jest.fn();
+        fields = mount(
+          <HorizontalFields
+            schema={schema}
+            formData={formData}
+            onChange={onChangeSpy}
+          />
+        );
+      });
+
+      it("Renders the currency component from the registry", () => {
+        expect(fields.find("textarea").length).toEqual(1);
+      });
+
+      it("Calls the onChange method passed in with the form data", () => {
+        fields
+          .find("textarea")
+          .simulate("change", { target: { value: "Another Meow" } });
+
+        expect(onChangeSpy).toHaveBeenCalledWith({ meow: "Another Meow" });
+      });
+    });
+  });
 
   describe("Given a single field", () => {
     describe("Example one", () => {

--- a/src/Components/HorizontalFields/index.js
+++ b/src/Components/HorizontalFields/index.js
@@ -69,6 +69,17 @@ export default class HorizontalFields extends React.Component {
           onChange={e => this.onChange(k, e.target.value)}
         />
       );
+    } else if (v.extendedText) {
+      return (
+        <textarea
+          id={k}
+          disabled={v.readonly}
+          data-test={`${k}-input`}
+          type={this.inputFieldType(v)}
+          value={this.state[k]}
+          onChange={e => this.onChange(k, e.target.value)}
+        />
+      );
     } else {
       return (
         <input

--- a/test/WidgetStub/index.js
+++ b/test/WidgetStub/index.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default class WidgetStub extends React.Component {
+  render() {
+    return <input data-test={this.datatest} value={this.props.value || ""} onChange={e => this.props.onChange(e)}/>;
+  }
+}


### PR DESCRIPTION
Why - So https://github.com/homes-england/monitor-api/pull/178 will work correctly.
![deepinscreenshot_select-area_20181108150453](https://user-images.githubusercontent.com/41294831/48207039-b275c780-e367-11e8-8d26-858a46501cea.png)
