### PR TITLE
Force to rerended after delete button pressed

### DIFF
--- a/src/Components/QuarterlyBreakdown/index.js
+++ b/src/Components/QuarterlyBreakdown/index.js
@@ -120,6 +120,8 @@ export default class QuarterlyBreakdown extends React.Component {
     updatedArray.splice(index, 1);
 
     this.setState({ data: updatedArray });
+    
+    this.forceUpdate();
   }
 
   render() {


### PR DESCRIPTION
WHY: 

When deleting a row in the middle it would delete the last one if there was nothing entered in the currency field and the state wasn't updating so it was rerendering.

WHAT: force it to Rerender when delete button is clicked.