### PR TITLE
Add conditional to cope with edge case where no legend has been set

### DIFF
--- a/src/Components/ParentForm/index.js
+++ b/src/Components/ParentForm/index.js
@@ -102,7 +102,9 @@ export default class ParentForm extends React.Component {
             });
           }
           let documentObject = this.props.documentGateway.getDocument();
-          documentObject.getElementById(jump_to_id).scrollIntoView();
+          if (documentObject.getElementById(jump_to_id)) {
+            documentObject.getElementById(jump_to_id).scrollIntoView();
+          }
         }}
       />
     );


### PR DESCRIPTION
WHAT: Checks for edge cases where the header that appears in the sidebar isn't a top level header with a legend tag.

WHY: Resolves an error that occurs when a sidebar item in the situation is clicked.