### PR TITLE
Emphasise selected item in sidebar

### DIFF
--- a/src/Components/ParentForm/index.js
+++ b/src/Components/ParentForm/index.js
@@ -99,6 +99,7 @@ export default class ParentForm extends React.Component {
       <Sidebar
         items={items}
         selectedFormItemIndex={this.state.selectedFormItemIndex}
+        selectedFormSection={this.state.selectedFormSection}
         onItemClick={(section, index) => {
           let jump_to_id;
           if (this.selectedSchema().type === "object") {

--- a/src/Components/Sidebar/index.js
+++ b/src/Components/Sidebar/index.js
@@ -3,29 +3,47 @@ import PropTypes from "prop-types";
 import "./style.css";
 
 export default class Sidebar extends React.Component {
-  renderChildren(children) {
+
+  renderChildren(children, selectedIndex) {
     return Object.entries(children).map(([key, value]) => (
       <li key={key} data-test="sidebar-item-child">
         <a
-          className="sidebar-item"
+          className={this.selectedChildStyling(key, selectedIndex)}
           onClick={_ => this.props.onItemClick(value.subSection, value.index)}
           data-test="sidebar-item-child-button"
-        >
+          >
           {value.title}
         </a>
       </li>
     ));
   }
 
+  selectedChildStyling(key, selectedIndex) {
+    if (
+      this.props.selectedFormSection === key &&
+      selectedIndex === this.props.selectedFormItemIndex
+    ) {
+      return "selected-item";
+    } else {
+      return "sidebar-item";
+    }
+  }
+
   renderSidebarItem(item, key) {
-    if(parseInt(key, 10) === this.props.selectedFormItemIndex) {
+    if (parseInt(key, 10) === this.props.selectedFormItemIndex) {
       return (
         <React.Fragment>
-          <span className="sidebar-parent selected" data-test="sidebar-item-button">
+          <span
+            className="sidebar-parent selected-header"
+            data-test="sidebar-item-button"
+          >
             {item.title}
           </span>
           <ul data-test="sidebar-item-children">
-            {this.renderChildren(item.children)}
+            {this.renderChildren(
+              item.children,
+              this.props.selectedFormItemIndex
+            )}
           </ul>
         </React.Fragment>
       );
@@ -52,8 +70,6 @@ export default class Sidebar extends React.Component {
       );
     }
   }
-
-
 
   renderItems() {
     return Object.entries(this.props.items).map(([key, value]) => (

--- a/src/Components/Sidebar/style.css
+++ b/src/Components/Sidebar/style.css
@@ -12,7 +12,12 @@
   cursor: pointer;
 }
 
-.selected {
+.selected-header {
   color: #005ea5;
   text-decoration: underline;
+}
+
+.selected-item {
+  color: #005ea5;
+  font-weight: bold;
 }


### PR DESCRIPTION
In addition to showing the selected infrastructure in the sidebar, it now highlights the selected sub-heading as well.

CURRENT:
<img width="448" alt="screenshot 2018-11-27 at 11 52 35" src="https://user-images.githubusercontent.com/20663545/49080253-f4917b00-f23a-11e8-82dd-6d5af0ab2ccf.png">

PREVIOUS:
<img width="443" alt="screenshot 2018-11-27 at 11 56 14" src="https://user-images.githubusercontent.com/20663545/49080412-77b2d100-f23b-11e8-88db-9987916897ce.png">
