### PR TITLE
Resolve widget re-rendering issue

### DIFF
--- a/src/Components/CurrencyWidget/index.js
+++ b/src/Components/CurrencyWidget/index.js
@@ -6,8 +6,7 @@ export default class CurrencyWidget extends React.Component {
     super(props);
     this.state = {
       value: this.formatNumber(''+this.props.value),
-      currency: this.props.currency ? this.props.currency : "£",
-      key: this.props.key
+      currency: this.props.currency ? this.props.currency : "£"
     };
   }
 

--- a/src/Components/PeriodsField/PeriodsField.test.js
+++ b/src/Components/PeriodsField/PeriodsField.test.js
@@ -49,7 +49,7 @@ describe("Period Financials", () => {
       });
 
       it("Does not display a remove button", () => {
-        expect(periods.numberOfRemoveButton()).toEqual(0);
+        expect(periods.removeButton()).toEqual(0);
       });
     });
     describe("Example 2", () => {
@@ -97,7 +97,7 @@ describe("Period Financials", () => {
       });
 
       it("Does not display a remove button", () => {
-        expect(periods.numberOfRemoveButton()).toEqual(0);
+        expect(periods.removeButton()).toEqual(0);
       });
     });
   });
@@ -159,7 +159,7 @@ describe("Period Financials", () => {
       });
 
       it("Displays a remove button", () => {
-        expect(periods.numberOfRemoveButton()).toEqual(2);
+        expect(periods.removeButton()).toEqual(1);
       });
     });
 
@@ -225,7 +225,7 @@ describe("Period Financials", () => {
       });
 
       it("Displays a remove button", () => {
-        expect(periods.numberOfRemoveButton()).toEqual(3);
+        expect(periods.removeButton()).toEqual(1);
       });
     });
   });

--- a/src/Components/PeriodsField/index.js
+++ b/src/Components/PeriodsField/index.js
@@ -70,7 +70,7 @@ export default class PeriodsField extends React.Component {
     if (!this.props.schema.addable) {
       return null;
     }
-    return <RemoveButton onClick={() => this.removeEvent(index)} />;
+    return <RemoveButton onClick={() => this.removeEvent(index)} index={index} />;
   }
 
   addEvent() {

--- a/src/Components/QuarterlyBreakdown/QuartelyBreakdown.test.js
+++ b/src/Components/QuarterlyBreakdown/QuartelyBreakdown.test.js
@@ -1,7 +1,6 @@
 import QuarterlyBreakdown from ".";
 import { mount } from "enzyme";
 import React from "react";
-import CurrencyWidget from "../CurrencyWidget";
 
 describe("Quarterly Breakdown", () => {
   describe("Readonly Data", () => {

--- a/src/Components/QuarterlyBreakdown/QuartelyBreakdown.test.js
+++ b/src/Components/QuarterlyBreakdown/QuartelyBreakdown.test.js
@@ -1,6 +1,7 @@
 import QuarterlyBreakdown from ".";
 import { mount } from "enzyme";
 import React from "react";
+import CurrencyWidget from "../CurrencyWidget";
 
 describe("Quarterly Breakdown", () => {
   describe("Readonly Data", () => {
@@ -185,7 +186,7 @@ describe("Quarterly Breakdown", () => {
       });
 
       it("Does not render a remove button", () => {
-        expect(field.find('[data-test="remove-button"]').length).toEqual(0);
+        expect(field.find('[data-test="remove-button-0"]').length).toEqual(0);
       });
     });
 
@@ -309,7 +310,7 @@ describe("Quarterly Breakdown", () => {
       });
 
       it("Does not render a remove button", () => {
-        expect(field.find('[data-test="remove-button"]').length).toEqual(0);
+        expect(field.find('[data-test="remove-button-0"]').length).toEqual(0);
       });
     });
   });
@@ -380,7 +381,7 @@ describe("Quarterly Breakdown", () => {
       });
 
       it("renders a remove button", () => {
-        expect(field.find('[data-test="remove-button"]').length).toEqual(2);
+        expect(field.find('[data-test="remove-button-0"]').length).toEqual(1);
       });
     });
 
@@ -449,7 +450,7 @@ describe("Quarterly Breakdown", () => {
       });
 
       it("renders a remove button", () => {
-        expect(field.find('[data-test="remove-button"]').length).toEqual(2);
+        expect(field.find('[data-test="remove-button-0"]').length).toEqual(1);
       });
     });
   });
@@ -500,7 +501,7 @@ describe("Quarterly Breakdown", () => {
       });
 
       it("does not render a remove button", () => {
-        expect(field.find('[data-test="remove-button"]').length).toEqual(0);
+        expect(field.find('[data-test="remove-button-0"]').length).toEqual(0);
       });
     });
 
@@ -549,7 +550,7 @@ describe("Quarterly Breakdown", () => {
       });
 
       it("does not render a remove button", () => {
-        expect(field.find('[data-test="remove-button"]').length).toEqual(0);
+        expect(field.find('[data-test="remove-button-0"]').length).toEqual(0);
       });
     });
   });
@@ -558,67 +559,8 @@ describe("Quarterly Breakdown", () => {
     let schema, data, field, onChangeSpy;
     describe("Example 1", () => {
       beforeEach(() => {
-          onChangeSpy = jest.fn();
-  
-          schema = {
-            type: "array",
-            addable: true,
-            title: "Cats Data",
-            items: {
-              type: "object",
-              properties: {
-                period: { title: "Year", type: "string", readonly: true },
-                quarter3: { title: "3rd Quarter", enum: ["yes", "no"], type: "string" },
-                quarter1: { title: "1st Quarter", type: "string" },
-                quarter2: { title: "2nd Quarter", type: "string" },
-                quarter4: { title: "4th Quarter", type: "string" },
-                total: { title: "Total", type: "string" }
-              }
-            }
-          };
-  
-          data = [
-            {
-              period: "2018",
-              quarter3: "yes"
-            },
-            {
-              period: "2019"
-            }
-          ];
-          field = mount(
-            <QuarterlyBreakdown
-              schema={schema}
-              formData={data}
-              onChange={onChangeSpy}
-            />
-          );
-        });
-  
-        it("shows a select for any enum schema data", () => {
-          expect(field.find('select[data-test="quarter3_0"]').length).toEqual(1);
-        });
-  
-        it("prepopulates the input field with the form data", () => {
-          expect(field.find('select[data-test="quarter3_0"]').props().value).toEqual(
-            "yes"
-          );
-        });
-  
-        it("call the onChange method with the form data", () => {
-          field
-            .find('[data-test="quarter3_0"]')
-            .simulate("change", { target: { value: "No" } });
-          expect(onChangeSpy).toHaveBeenCalledWith([
-            { period: "2018", quarter3: "No" },
-            { period: "2019" }
-          ]);
-        });
-    });
-    describe("Example 2", () => {
-      beforeEach(() => {
         onChangeSpy = jest.fn();
-  
+
         schema = {
           type: "array",
           addable: true,
@@ -627,7 +569,11 @@ describe("Quarterly Breakdown", () => {
             type: "object",
             properties: {
               period: { title: "Year", type: "string", readonly: true },
-              quarter3: { title: "3rd Quarter", enum: ["Hi", "Bye"], type: "string" },
+              quarter3: {
+                title: "3rd Quarter",
+                enum: ["yes", "no"],
+                type: "string"
+              },
               quarter1: { title: "1st Quarter", type: "string" },
               quarter2: { title: "2nd Quarter", type: "string" },
               quarter4: { title: "4th Quarter", type: "string" },
@@ -635,7 +581,70 @@ describe("Quarterly Breakdown", () => {
             }
           }
         };
-  
+
+        data = [
+          {
+            period: "2018",
+            quarter3: "yes"
+          },
+          {
+            period: "2019"
+          }
+        ];
+        field = mount(
+          <QuarterlyBreakdown
+            schema={schema}
+            formData={data}
+            onChange={onChangeSpy}
+          />
+        );
+      });
+
+      it("shows a select for any enum schema data", () => {
+        expect(field.find('select[data-test="quarter3_0"]').length).toEqual(1);
+      });
+
+      it("prepopulates the input field with the form data", () => {
+        expect(
+          field.find('select[data-test="quarter3_0"]').props().value
+        ).toEqual("yes");
+      });
+
+      it("call the onChange method with the form data", () => {
+        field
+          .find('[data-test="quarter3_0"]')
+          .simulate("change", { target: { value: "No" } });
+        expect(onChangeSpy).toHaveBeenCalledWith([
+          { period: "2018", quarter3: "No" },
+          { period: "2019" }
+        ]);
+      });
+    });
+    describe("Example 2", () => {
+      beforeEach(() => {
+        onChangeSpy = jest.fn();
+
+        schema = {
+          type: "array",
+          addable: true,
+          title: "Cats Data",
+          items: {
+            type: "object",
+            properties: {
+              period: { title: "Year", type: "string", readonly: true },
+              quarter3: {
+                title: "3rd Quarter",
+                enum: ["Hi", "Bye"],
+                type: "string"
+              },
+              quarter1: { title: "1st Quarter", type: "string" },
+              quarter2: { title: "2nd Quarter", type: "string" },
+              quarter4: { title: "4th Quarter", type: "string" },
+              total: { title: "Total", type: "string" }
+            }
+          }
+        };
+
         data = [
           {
             period: "2020",
@@ -653,17 +662,17 @@ describe("Quarterly Breakdown", () => {
           />
         );
       });
-  
+
       it("shows a select for any enum schema data", () => {
         expect(field.find('select[data-test="quarter3_0"]').length).toEqual(1);
       });
-  
+
       it("prepopulates the input field with the form data", () => {
-        expect(field.find('select[data-test="quarter3_0"]').props().value).toEqual(
-          "Hi"
-        );
+        expect(
+          field.find('select[data-test="quarter3_0"]').props().value
+        ).toEqual("Hi");
       });
-  
+
       it("calls the onChange method with the form data", () => {
         field
           .find('[data-test="quarter3_0"]')
@@ -672,6 +681,158 @@ describe("Quarterly Breakdown", () => {
           { period: "2020", quarter3: "Bye" },
           { period: "2021" }
         ]);
+      });
+    });
+  });
+
+  describe("Number of Rows", () => {
+    describe("Example 1", () => {
+      let schema, data, field, onChangeSpy;
+      beforeEach(() => {
+        onChangeSpy = jest.fn();
+
+        schema = {
+          type: "array",
+          addable: true,
+          title: "Cats Data",
+          items: {
+            type: "object",
+            properties: {
+              period: { title: "Year", type: "string", readonly: true },
+              quarter1: { title: "1st Quarter", type: "string" },
+              quarter2: { title: "2nd Quarter", type: "string" },
+              quarter3: { title: "3rd Quarter", type: "string" },
+              quarter4: { title: "4th Quarter", type: "string" },
+              total: { title: "Total", type: "string" }
+            }
+          }
+        };
+
+        data = [
+          {
+            period: "2018",
+            quarter1: "2000",
+            quarter2: "3000",
+            quarter3: "4000",
+            quarter4: "5000",
+            total: "14000"
+          },
+          {
+            period: "2019",
+            quarter1: "1000",
+            quarter2: "2000",
+            quarter3: "3000",
+            quarter4: "4000",
+            total: "10000"
+          }
+        ];
+        field = mount(
+          <QuarterlyBreakdown
+            schema={schema}
+            formData={data}
+            onChange={onChangeSpy}
+          />
+        );
+      });
+
+      it("renders an add button", () => {
+        expect(field.find('[data-test="add-button"]').length).toEqual(1);
+      });
+
+      it("renders a remove button", () => {
+        expect(field.find('[data-test="remove-button-0"]').length).toEqual(1);
+      });
+
+      it("shows the number of rows in the key", () => {
+        expect(field.find('[data-test="quarter1_0"]').key()).toEqual(
+          "quarter1_0_2"
+        );
+      });
+
+      it("updates the number of rows in the key", () => {
+        field.find('[data-test="remove-button-0"]').simulate("click");
+        expect(field.find('[data-test="quarter1_0"]').key()).toEqual(
+          "quarter1_0_1"
+        );
+      });
+    });
+
+    describe("Example 2", () => {
+      let schema, data, field, onChangeSpy;
+      beforeEach(() => {
+        onChangeSpy = jest.fn();
+
+        schema = {
+          type: "array",
+          addable: true,
+          title: "Cats Data",
+          items: {
+            type: "object",
+            properties: {
+              period: { title: "Year", type: "string", readonly: true },
+              quarter1: { title: "1st Quarter", type: "string" },
+              quarter2: { title: "2nd Quarter", type: "string" },
+              quarter3: { title: "3rd Quarter", type: "string" },
+              quarter4: { title: "4th Quarter", type: "string" },
+              total: { title: "Total", type: "string" }
+            }
+          }
+        };
+
+        data = [
+          {
+            period: "1",
+            quarter1: "7",
+            quarter2: "9",
+            quarter3: "3",
+            quarter4: "5",
+            total: "120348"
+          },
+          {
+            period: "2",
+            quarter1: "3",
+            quarter2: "4",
+            quarter3: "5",
+            quarter4: "6",
+            total: "18"
+          },
+          {
+            period: "3",
+            quarter1: "654",
+            quarter2: "54235",
+            quarter3: "4325",
+            quarter4: "84568",
+            total: "348932748"
+          }
+        ];
+        field = mount(
+          <QuarterlyBreakdown
+            schema={schema}
+            formData={data}
+            onChange={onChangeSpy}
+          />
+        );
+      });
+
+      it("renders an add button", () => {
+        expect(field.find('[data-test="add-button"]').length).toEqual(1);
+      });
+
+      it("renders a remove button", () => {
+        expect(field.find('[data-test="remove-button-0"]').length).toEqual(1);
+      });
+
+      it("shows the number of rows in the key", () => {
+        expect(field.find('[data-test="quarter1_0"]').key()).toEqual(
+          "quarter1_0_3"
+        );
+      });
+
+      it("updates the number of rows in the key", () => {
+        field.find('[data-test="remove-button-0"]').simulate("click");
+        expect(field.find('[data-test="quarter1_0"]').key()).toEqual(
+          "quarter1_0_2"
+        );
       });
     });
   });

--- a/src/Components/QuarterlyBreakdown/index.js
+++ b/src/Components/QuarterlyBreakdown/index.js
@@ -94,6 +94,7 @@ export default class QuarterlyBreakdown extends React.Component {
   }
 
   renderInputField(key, periodData, index, v) {
+    let numberOfRows = Object.keys(this.state.data).length
     if (!periodData) return
     if (v.currency) {
       return (
@@ -101,7 +102,7 @@ export default class QuarterlyBreakdown extends React.Component {
           data-test={`${key}_${index}`}
           className="form-control"
           value={periodData[key]}
-          key={`${key}_${index}_${periodData[key]}`}
+          key={`${key}_${index}_${numberOfRows}`}
           onChange={e => this.onFieldChange(index, key, e)}
           disabled={v.readonly}
         />

--- a/src/Components/QuarterlyBreakdown/index.js
+++ b/src/Components/QuarterlyBreakdown/index.js
@@ -115,6 +115,7 @@ export default class QuarterlyBreakdown extends React.Component {
         data-test={`${key}_${index}`}
         className="form-control"
         value={periodData[key]}
+        key={`${key}_${index}_${numberOfRows}`}
         onChange={e => this.onFieldChange(index, key, e.target.value)}
         disabled={v.readonly}
       />
@@ -139,7 +140,7 @@ export default class QuarterlyBreakdown extends React.Component {
 
   renderRemoveButton(index) {
     if (this.props.schema.addable) {
-      return <div className="remove"><RemoveButton onClick={() => this.removeEvent(index)} /></div>;
+      return <div className="remove"><RemoveButton onClick={() => this.removeEvent(index)} index={index}/></div>;
     }
     return null;
   }

--- a/src/Components/QuarterlyBreakdown/index.js
+++ b/src/Components/QuarterlyBreakdown/index.js
@@ -101,12 +101,12 @@ export default class QuarterlyBreakdown extends React.Component {
           data-test={`${key}_${index}`}
           className="form-control"
           value={periodData[key]}
-          key={`${key}_${index}`}
+          key={`${key}_${index}_${periodData[key]}`}
           onChange={e => this.onFieldChange(index, key, e)}
           disabled={v.readonly}
         />
       );
-    } else if (v.enum) { 
+    } else if (v.enum) {
       return this.renderDropdown(key, periodData[key], v, index)
     } else {
       return (

--- a/src/Components/RemoveButton/index.js
+++ b/src/Components/RemoveButton/index.js
@@ -6,7 +6,7 @@ export default class RemoveButton extends React.Component {
       <div className="row">
         <div className="pull-right">
           <button
-            data-test="remove-button"
+            data-test={`remove-button-${this.props.index}`}
             className="btn btn-danger"
             onClick={this.props.onClick}
           >

--- a/src/UseCase/GenerateSidebarItems/index.js
+++ b/src/UseCase/GenerateSidebarItems/index.js
@@ -13,8 +13,6 @@ export default class GenerateSidebarItems {
 
   generateItemsForArray(schema, data) {
     let items = {};
-    console.log(data)
-    console.log(schema)
     data.forEach((_, i) => {
       items[i] = {
         title: `${schema.items.title} ${i + 1}`,

--- a/test/PeriodsField/index.js
+++ b/test/PeriodsField/index.js
@@ -53,8 +53,8 @@ export default class Periods {
     this.page.find('[data-test="add-button"]').simulate('click');
   }
 
-  numberOfRemoveButton() {
-    return this.page.find('[data-test="remove-button"]').length;
+  removeButton() {
+    return this.page.find('[data-test="remove-button-0"]').length;
   }
 
   pressRemove() {


### PR DESCRIPTION
WHAT:
Adds a unique key to the currency widget setup to cause rerender at the correct times. (i.e. when a row is added or removed).

WHY:
The previous behaviour of these input fields was that they weren't rerendering when a row was added or deleted.