### PR TITLE
Add blank option to dropdowns in horizontalFields

### DIFF
--- a/src/Components/HorizontalFields/horizontalFields.test.js
+++ b/src/Components/HorizontalFields/horizontalFields.test.js
@@ -494,9 +494,10 @@ describe("<HorizontalFields>", () => {
         let dropdown = fields.find("[data-test='meow-input']");
         let options = dropdown.children();
 
-        expect(dropdown.children().length).toEqual(2);
-        expect(options.at(0).text()).toEqual("Cat");
-        expect(options.at(1).text()).toEqual("Kitten");
+        expect(dropdown.children().length).toEqual(3);
+        expect(options.at(0).text()).toEqual("");
+        expect(options.at(1).text()).toEqual("Cat");
+        expect(options.at(2).text()).toEqual("Kitten");
         expect(dropdown.props().value).toEqual("Cat");
       });
 
@@ -561,10 +562,11 @@ describe("<HorizontalFields>", () => {
         let dropdown = fields.find("[data-test='woof-input']");
         let options = dropdown.children();
 
-        expect(dropdown.children().length).toEqual(3);
-        expect(options.at(0).text()).toEqual("Dog");
-        expect(options.at(1).text()).toEqual("Pupper");
-        expect(options.at(2).text()).toEqual("Puppy");
+        expect(dropdown.children().length).toEqual(4);
+        expect(options.at(0).text()).toEqual("");
+        expect(options.at(1).text()).toEqual("Dog");
+        expect(options.at(2).text()).toEqual("Pupper");
+        expect(options.at(3).text()).toEqual("Puppy");
         expect(dropdown.props().value).toEqual("Pupper");
       });
 

--- a/src/Components/HorizontalFields/index.js
+++ b/src/Components/HorizontalFields/index.js
@@ -41,6 +41,7 @@ export default class HorizontalFields extends React.Component {
       value={this.state[propertyName] || schema.default}
       data-test={`${propertyName}-input`}
     >
+      <option key="blank"></option>
       {schema.enum.map(optionValue => (
         <option key={optionValue}>{optionValue}</option>
       ))}


### PR DESCRIPTION
WHAT: Adds a blank option to the horizontalField dropdowns to show that the field needs to be selected to be filled in.

WHY: Before, the dropdowns all showed "High" as the top enum. However, if the user didn't explicitly go into the field and change the dropdown to High manually, there was no onChange event and thus the data was never saved.