### PR TITLE
Create an endpoint to print a return

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React from "react";
 import qs from "qs";
 
-import BaselineData from "./Components/BaselineData";
+import StaticData from "./Components/StaticData";
 import Homepage from "./Components/Homepage";
 import Footer from "./Components/Footer";
 import Header from "./Components/Header";
@@ -177,7 +177,7 @@ const renderBaselinePage = props => (
     {({ formData, formSchema }) => (
       <div className="col-md-10 col-md-offset-1">
         <BackToProjectOverviewButton {...props} />
-        <BaselineData formData={formData} schema={formSchema} />
+        <StaticData formData={formData} schema={formSchema} />
         <div className="col-md-2">
           <CreateReturnButton {...props} />
         </div>
@@ -190,7 +190,7 @@ const renderPrintPage = props => (
    <PrintReturn {...props} getReturn={getReturnUseCase} >
     {({schema, data}) => (
       <div>
-        <BaselineData formData={data} schema={schema} />
+        <StaticData formData={data} schema={schema} />
       </div>
     )}
    </PrintReturn>

--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import ReturnPage from "./Components/ReturnPage";
 import Portal from "./Components/Portal";
 import NotFound from "./Components/NotFound";
 import CookieConsent from "./Components/CookieConsent";
+import PrintReturn from "./Components/PrintReturn";
 
 import CreateReturn from "./UseCase/CreateReturn";
 import SubmitProject from "./UseCase/SubmitProject";
@@ -185,6 +186,17 @@ const renderBaselinePage = props => (
   </ProjectPage>
 );
 
+const renderPrintPage = props => (
+   <PrintReturn {...props} getReturn={getReturnUseCase} >
+    {({schema, data}) => (
+      <div>
+        <BaselineData formData={data} schema={schema} />
+      </div>
+    )}
+   </PrintReturn>
+);
+
+
 const App = () => (
   <Router>
     <div className="app-container">
@@ -229,6 +241,11 @@ const App = () => (
                   exact
                   path="/project/:projectId/return/:returnId"
                   render={renderReturnPage}
+                />
+                <Route 
+                  exact
+                  path="/project/:projectId/return/:returnId/print"
+                  render={renderPrintPage}
                 />
               </Portal>
             )}

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -364,6 +364,38 @@ describe('Submitting a draft project', () => {
   });
 });
 
+describe("Printing a return", () => {
+  let api;
+  beforeEach(() => {
+    process.env.REACT_APP_HIF_API_URL = "http://cat.meow/";
+    api = new APISimulator("http://cat.meow");
+  });
+
+  afterEach(()=> {
+    nock.cleanAll();
+  })
+
+  xit("Renders the return data", async () => {
+    let data = {
+      cat: "meow",
+      dog: "woof"
+    }
+    let schema = {
+      type: "object",
+      properties: {
+        cat: {type: "string"},
+        dog: {type: "string"}
+      }
+    }
+    api.getReturn(data, schema).successfully();
+
+    let page = new AppPage("/project/0/return/1/print");
+    await page.load();
+
+    expect(page.find('PrintReturn').length).toEqual(1)
+  });
+});
+
 describe("Page not found", () => {
   it("Renders a 404 page", async () => {
     let page = new AppPage("/non-existent");

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -243,7 +243,7 @@ describe("Viewing a project", () => {
         api.getProject(projectSchema, projectData, projectStatus, projectType).successfully();
         await page.viewBaseline();
 
-        expect(page.find('BaselineData').length).toEqual(1)
+        expect(page.find('StaticData').length).toEqual(1)
       });
 
       it("Renders the return with information from the API when creating a new return", async () => {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -367,15 +367,15 @@ describe('Submitting a draft project', () => {
 describe("Printing a return", () => {
   let api;
   beforeEach(() => {
-    process.env.REACT_APP_HIF_API_URL = "http://cat.meow/";
-    api = new APISimulator("http://cat.meow");
+    process.env.REACT_APP_HIF_API_URL = "http://dog.woof/";
+    api = new APISimulator("http://dog.woof");
   });
 
   afterEach(()=> {
     nock.cleanAll();
   })
 
-  xit("Renders the return data", async () => {
+  it("Renders the return data", async () => {
     let data = {
       cat: "meow",
       dog: "woof"
@@ -387,12 +387,15 @@ describe("Printing a return", () => {
         dog: {type: "string"}
       }
     }
+    api.getProject(schema, data, "Submitted", "hif").successfully();
     api.getReturn(data, schema).successfully();
-
-    let page = new AppPage("/project/0/return/1/print");
+    
+    let page = new AppPage("/project/0/return/1/print?token=Cats");
     await page.load();
 
+
     expect(page.find('PrintReturn').length).toEqual(1)
+    expect(page.find('StaticData').length).toEqual(1)
   });
 });
 

--- a/src/Components/BaselineData/index.js
+++ b/src/Components/BaselineData/index.js
@@ -97,6 +97,7 @@ export default class BaselineData extends React.Component {
   };
 
   render() {
+    console.log(this.props.schema)
     return (
       <div className="panel panel-default">
         <div className="panel-heading">

--- a/src/Components/Footer/style.css
+++ b/src/Components/Footer/style.css
@@ -37,3 +37,9 @@ footer {
 footer a{
   color: inherit;
 }
+
+@media print {
+  footer {
+    display: none;
+  }
+}

--- a/src/Components/Header/style.css
+++ b/src/Components/Header/style.css
@@ -21,3 +21,9 @@
   height: 89%;
   padding: 5px 0 1px 30px;
 }
+
+@media print {
+  .monitor-header {
+    display: none;
+  }
+}

--- a/src/Components/ParentForm/index.js
+++ b/src/Components/ParentForm/index.js
@@ -9,7 +9,7 @@ import MilestoneField from "../MilestoneField";
 import PercentageField from "../PercentageField";
 import GenerateSidebarItems from "../../UseCase/GenerateSidebarItems";
 import RiskField from "../RiskField";
-import BaselineData from "../BaselineData";
+import StaticData from "../StaticData";
 import PeriodsField from "../PeriodsField";
 import NumberedArrayField from "../NumberedArrayField";
 import QuarterlyBreakdown from "../QuarterlyBreakdown";
@@ -147,7 +147,7 @@ export default class ParentForm extends React.Component {
       variance: VarianceField,
       risk: RiskField,
       periods: PeriodsField,
-      base: BaselineData,
+      base: StaticData,
       milestone: MilestoneField,
       numbered: NumberedArrayField,
       quarterly: QuarterlyBreakdown

--- a/src/Components/PrintReturn/index.js
+++ b/src/Components/PrintReturn/index.js
@@ -1,0 +1,62 @@
+import React from 'react';
+
+export default class PrintReturn extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      loading: true,
+      formData: null
+    }
+
+  }
+
+  presentReturnNotFound = async () => {};
+
+  fetchData =  () => {
+   this.props.getReturn.execute(this, {
+      id: this.props.match.params.returnId,
+      projectId: this.props.match.params.projectId
+    });
+  };
+
+  componentDidMount() {
+    document.title = "Return - Homes England Monitor";
+    this.fetchData();
+  }
+
+  componentDidUpdate() {
+    window.print()
+   }
+
+  presentReturn = async returnData => {
+    await this.setState({
+      loading: false,
+      data: returnData.data,
+      schema: returnData.schema
+    });
+  }
+
+  renderChildren = () => {
+    return(
+      <div>{this.props.children({
+        data: this.state.data,
+        schema: this.state.schema
+      })}
+      </div>
+    )
+  }
+
+  
+  render = () => {
+    if (this.state.loading) {
+      return <div />;
+    } else {
+      return (
+        <div >
+        {this.renderChildren()}
+        </div>
+      )
+    }
+  }
+}

--- a/src/Components/PrintReturn/printReturn.test.js
+++ b/src/Components/PrintReturn/printReturn.test.js
@@ -21,7 +21,7 @@ describe("Print Return", () => {
 
       page = shallow(
         <PrintReturn
-          match={{ params: { id: "1", projectId: "4" } }}
+          match={{ params: { returnId: "1", projectId: "4" } }}
           getReturn={getReturnSpy}
         >
         {childrenSpy}
@@ -71,7 +71,7 @@ describe("Print Return", () => {
 
       page = shallow(
         <PrintReturn
-          match={{ params: { id: "2", projectId: "5" } }}
+          match={{ params: { returnId: "2", projectId: "5" } }}
           getReturn={getReturnSpy}
         >
         {childrenSpy}

--- a/src/Components/PrintReturn/printReturn.test.js
+++ b/src/Components/PrintReturn/printReturn.test.js
@@ -1,0 +1,104 @@
+import React from "react";
+import PrintReturn from ".";
+import { shallow } from "enzyme";
+
+describe("Print Return", () => {
+  describe("Example 1", () => {
+    let page, getReturnSpy, childrenSpy;
+    beforeEach(() => {
+      getReturnSpy = {
+        execute: jest.fn((presenter, _) =>
+          presenter.presentReturn({
+            data: { kitty: "purrr" },
+            schema: { type: "cat", title: "Kitty" },
+            status: "Submitted",
+            type: "ac"
+          })
+        )
+      };
+
+      childrenSpy = jest.fn();
+
+      page = shallow(
+        <PrintReturn
+          match={{ params: { id: "1", projectId: "4" } }}
+          getReturn={getReturnSpy}
+        >
+        {childrenSpy}
+        </PrintReturn>
+
+      );
+    });
+
+    it("Calls the getReturn usecase when loaded", () => {
+      expect(getReturnSpy.execute).toHaveBeenCalledWith(expect.anything(), {
+        id: "1",
+        projectId: "4"
+      });
+    });
+
+    it("Holds the data when the return is presented", () => {
+      expect(page.state().data).toEqual({ kitty: "purrr" });
+    });
+
+    it("Holds the schmea when the return is presented", () => {
+      expect(page.state().schema).toEqual({ type: "cat", title: "Kitty" });
+    });
+
+    it("Call its children with the correct props", ()=> {
+      expect(childrenSpy).toHaveBeenCalledWith({
+        schema: { type: "cat", title: "Kitty" },
+        data: { kitty: "purrr" }
+      })
+    })
+  });
+
+  describe("Example 2", () => {
+    let page, getReturnSpy, childrenSpy;
+    beforeEach(() => {
+      getReturnSpy = {
+        execute: jest.fn((presenter, _) =>
+          presenter.presentReturn({
+            data: { doggy: "woofy" },
+            schema: { type: "dog", title: "Woof" },
+            status: "Submitted",
+            type: "hif"
+          })
+        )
+      };
+
+      childrenSpy = jest.fn();
+
+      page = shallow(
+        <PrintReturn
+          match={{ params: { id: "2", projectId: "5" } }}
+          getReturn={getReturnSpy}
+        >
+        {childrenSpy}
+        </PrintReturn>
+      );
+    });
+
+    it("Calls the getReturn usecase when loaded", () => {
+      expect(getReturnSpy.execute).toHaveBeenCalledWith(expect.anything(), {
+        id: "2",
+        projectId: "5"
+      });
+    });
+
+    it("Holds the data when the return is presented", () => {
+      expect(page.state().data).toEqual({ doggy: "woofy" });
+    });
+
+    it("Holds the schmea when the return is presented", () => {
+      expect(page.state().schema).toEqual({ type: "dog", title: "Woof" });
+    });
+
+    it("Call its children with the correct props", ()=> {
+      expect(childrenSpy).toHaveBeenCalledWith({
+        schema: { type: "dog", title: "Woof" },
+        data: { doggy: "woofy" }
+      })
+    })
+  });
+});

--- a/src/Components/PrintReturn/stories.js
+++ b/src/Components/PrintReturn/stories.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PrintReturn from '.';
+import BaselineData from '../BaselineData';
+
+import { storiesOf } from "@storybook/react";
+
+storiesOf("Print Return", module).add("Default", () => {
+  let data = {cathouse: {cathouse: 'cat'}};
+  let schema = {
+    type: 'object',
+    properties: {
+      cathouse: {
+        type: 'object',
+        title: 'cathouse',
+        properties: {
+          cathouse: {
+            type: 'string',
+            readonly: true
+          }
+        }
+      }
+    }
+  }
+  let getReturnUseCase = { 
+    execute: (presenter, request) => {presenter.presentReturn({
+        status: 'Submitted',
+        data: data,
+        schema: schema
+    })}
+  }
+
+  return (
+    <PrintReturn 
+      getReturn={getReturnUseCase}
+      match={{params: {id: "3", projectId: "5" }}}
+    >
+  
+      {({data, schema}) => {
+        <BaselineData formData={data} schema={schema} />
+      }}
+    </PrintReturn>
+  )
+})

--- a/src/Components/PrintReturn/stories.js
+++ b/src/Components/PrintReturn/stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PrintReturn from '.';
-import BaselineData from '../BaselineData';
+import StaticData from '../StaticData';
 
 import { storiesOf } from "@storybook/react";
 
@@ -36,7 +36,7 @@ storiesOf("Print Return", module).add("Default", () => {
     >
   
       {({data, schema}) => {
-        <BaselineData formData={data} schema={schema} />
+        <StaticData formData={data} schema={schema} />
       }}
     </PrintReturn>
   )

--- a/src/Components/ProjectPage/stories.js
+++ b/src/Components/ProjectPage/stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ProjectPage from '.';
-import BaselineData from '../BaselineData'
+import StaticData from '../StaticData'
 
 import { storiesOf } from '@storybook/react';
 
@@ -40,7 +40,7 @@ storiesOf('ProjectPage', module)
       >
       {({ formData, formSchema }) => (
         <div className="col-md-10 col-md-offset-1">
-          <BaselineData formData={formData} schema={formSchema} />
+          <StaticData formData={formData} schema={formSchema} />
         </div>
       )}
     </ProjectPage>

--- a/src/Components/StaticData/index.js
+++ b/src/Components/StaticData/index.js
@@ -28,7 +28,7 @@ export default class StaticData extends React.Component {
 
   renderArray = (key, value, propertySchema) => {
     return (
-      <div>
+      <div key={`${key}`}>
         <div className="heading">{propertySchema.title}</div>
         {value.map((item, index) => {
           return (
@@ -81,6 +81,7 @@ export default class StaticData extends React.Component {
   };
 
   findInSchema = (schema, key) => {
+    if (!schema.properties) return
     if (key in schema.properties) {
       return schema.properties[key];
     } else if (schema.dependencies) {

--- a/src/Components/StaticData/index.js
+++ b/src/Components/StaticData/index.js
@@ -1,39 +1,53 @@
 import React from "react";
+import "./style.css";
 
-export default class BaselineData extends React.Component {
+export default class StaticData extends React.Component {
   renderObject = (key, value, propertySchema) => {
     return (
-      <div className="panel panel-default" key={key}>
-        <div className="panel-heading" data-test={`title-${key}`}>
+      <div className="section" key={key}>
+        <div className="heading" data-test={`title-${key}`}>
           {propertySchema.title}
         </div>
-        <div className="panel-body">
-          {this.renderFormData(value, propertySchema)}
+        <div className="body">{this.renderFormData(value, propertySchema)}</div>
+      </div>
+    );
+  };
+
+  renderArrayItem = (key, item, index, propertySchema) => {
+    return (
+      <div>
+        <div className="heading" data-test={`title-${key}`}>
+          {propertySchema.items.title} {index + 1}
+        </div>
+        <div className="body">
+          {this.renderFormData(item, propertySchema.items)}
         </div>
       </div>
     );
   };
 
   renderArray = (key, value, propertySchema) => {
-    return value.map((item, index) => {
-      return (
-        <div className="panel panel-default" key={`${key}_${index}`}>
-          <div className="panel-heading" data-test={`title-${key}`}>
-            {propertySchema.items.title} {index + 1}
-          </div>
-          <div className="panel-body">
-            {this.renderFormData(item, propertySchema.items)}
-          </div>
-        </div>
-      );
-    });
+    return (
+      <div>
+        <div className="heading">{propertySchema.title}</div>
+        {value.map((item, index) => {
+          return (
+            <div className="section" key={`${key}_${index}`}>
+              {this.renderArrayItem(key, item, index, propertySchema)}
+            </div>
+          );
+        })}
+      </div>
+    );
   };
 
   renderItem = (key, value, propertySchema) => {
     return (
       <div key={key}>
-        <h4 data-test={`title-${key}`}>{propertySchema.title}</h4>
-        <p data-test={key}>{value}</p>
+        <span className="print-title" data-test={`title-${key}`}>
+          {propertySchema.title}:{" "}
+        </span>
+        <span data-test={key}>{value}</span>
       </div>
     );
   };
@@ -97,13 +111,12 @@ export default class BaselineData extends React.Component {
   };
 
   render() {
-    console.log(this.props.schema)
     return (
-      <div className="panel panel-default">
-        <div className="panel-heading">
+      <div className="section">
+        <div className="heading">
           <h2 data-test="title">{this.props.schema.title}</h2>
         </div>
-        <div className="panel-body">
+        <div className="body">
           {this.renderFormData(this.props.formData, this.props.schema)}
         </div>
       </div>

--- a/src/Components/StaticData/staticData.test.js
+++ b/src/Components/StaticData/staticData.test.js
@@ -1,10 +1,10 @@
 import React from "react";
-import BaselineData from ".";
+import StaticData from ".";
 import { shallow, mount } from "enzyme";
 
 class BaselinePage {
   constructor(schema, formData) {
-    this.page = mount(<BaselineData schema={schema} formData={formData} />);
+    this.page = mount(<StaticData schema={schema} formData={formData} />);
   }
 
   title() {
@@ -55,7 +55,7 @@ describe("Baseline Data", () => {
 
       it("Display the title for a single string", () => {
         expect(page.find("[data-test='title-firstItem']").text()).toEqual(
-          "One of many of your items"
+          "One of many of your items: "
         );
       });
 
@@ -122,7 +122,7 @@ describe("Baseline Data", () => {
 
       it("Display the title for a single string", () => {
         expect(page.find("[data-test='title-secondItem']").text()).toEqual(
-          "a string"
+          "a string: "
         );
       });
 
@@ -547,7 +547,7 @@ describe("Baseline Data", () => {
         let page = new BaselinePage(schema, formData);
 
         expect(page.find("[data-test='woof']").text()).toEqual("No");
-        expect(page.find("[data-test='title-woof']").text()).toEqual("Woof");
+        expect(page.find("[data-test='title-woof']").text()).toEqual("Woof: ");
       });
 
       it("Displays the data appropriately with two oneOfs", () => {
@@ -594,7 +594,7 @@ describe("Baseline Data", () => {
 
         expect(page.find("[data-test='ribbit']").text()).toEqual("Croak");
         expect(page.find("[data-test='title-ribbit']").text()).toEqual(
-          "Ribbit"
+          "Ribbit: "
         );
         expect(page.find("[data-test='woof']").length).toEqual(0);
       });
@@ -650,7 +650,7 @@ describe("Baseline Data", () => {
 
         expect(page.find("[data-test='caw']").text()).toEqual("Buckaw");
         expect(page.find("[data-test='title-caw']").text()).toEqual(
-          "Bird Noise"
+          "Bird Noise: "
         );
       });
     });
@@ -689,7 +689,7 @@ describe("Baseline Data", () => {
 
         expect(page.find("[data-test='shout']").text()).toEqual("shhhh");
         expect(page.find("[data-test='title-shout']").text()).toEqual(
-          "Yelling"
+          "Yelling: "
         );
       });
 
@@ -736,7 +736,7 @@ describe("Baseline Data", () => {
         let page = new BaselinePage(schema, formData);
 
         expect(page.find("[data-test='dog']").text()).toEqual("runs");
-        expect(page.find("[data-test='title-dog']").text()).toEqual("big");
+        expect(page.find("[data-test='title-dog']").text()).toEqual("big: ");
         expect(page.find("[data-test='kitten']").length).toEqual(0);
       });
     });

--- a/src/Components/StaticData/stories.js
+++ b/src/Components/StaticData/stories.js
@@ -1,5 +1,5 @@
 import React from "react";
-import BaselineData from ".";
+import StaticData from ".";
 
 import { storiesOf } from "@storybook/react";
 
@@ -50,5 +50,5 @@ storiesOf("Baseline Data", module).add("Default", () => {
     croak: "No",
     caw: "Buckaw"
   };
-  return <BaselineData schema={schema} formData={formData} />;
+  return <StaticData schema={schema} formData={formData} />;
 });

--- a/src/Components/StaticData/style.css
+++ b/src/Components/StaticData/style.css
@@ -1,0 +1,16 @@
+.section {
+  padding-bottom: 4px;
+}
+.heading {
+  font-weight: bold;
+  padding-top: 2px;
+  padding-bottom: 2px;
+}
+.body {
+  padding-left: 1%;
+}
+
+.print-title { 
+  font-size: 1em;
+  margin-left: -4px;
+}

--- a/src/UseCase/GenerateSidebarItems/index.js
+++ b/src/UseCase/GenerateSidebarItems/index.js
@@ -13,6 +13,7 @@ export default class GenerateSidebarItems {
 
   generateItemsForArray(schema, data) {
     let items = {};
+    
     data.forEach((_, i) => {
       items[i] = {
         title: `${schema.items.title} ${i + 1}`,


### PR DESCRIPTION
- created a route for this.
- used the BaselineData component to display the data and hence renamed and restyled it. 

This is what it looks like saved as a PDF: 
[Return - Homes England Monitor2.pdf](https://github.com/homes-england/monitor-frontend/files/2632789/Return.-.Homes.England.Monitor2.pdf)
