### PR TITLE
Enable code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,13 @@ shell:
 	docker-compose run --rm web ash
 
 .PHONY: storybook
-storybook: 
+storybook:
 	docker-compose run --rm --service-ports web npm run storybook
 
 .PHONY: test
 test: docker-down docker-build
 	docker-compose run --rm web npm test
+
+.PHONY: coverage
+coverage: docker-down docker-build
+	docker-compose run --rm web npm run coverage

--- a/package.json
+++ b/package.json
@@ -24,9 +24,28 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
+    "coverage": "react-scripts test --env=jsdom --coverage",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 9009 -s public",
     "build-storybook": "build-storybook -s public"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+        "**/*.{js,jsx}",
+        "!**/node_modules/**",
+        "!**/stories.js",
+        "!**/coverage/**",
+        "!**/src/index.js",
+        "!**/src/registerServiceWorker.js"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 88,
+        "functions": 90,
+        "statements": 90,
+        "lines": 90
+      }
+    }
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.4.11",


### PR DESCRIPTION
**What**

Enables code coverage with a threshold of 90% (with the exception of Branch coverage is currently set to 88% until this can be improved). We've excluded stories, node modules, coverage and react bootstrapping code in src.

There will be a separate PR to integrate this into Continuous Pipeline, once PR is approved.

**Why**

The intention for enabling coverage is to identify untested code, and not as a benchmark for code actually being tested.

Which is why this is required by the SRE team ([checklist](https://github.com/madetech/productionisation/blob/master/PRODUCTIONISATION.md#2-testing)).