### PR TITLE
Add padding to title

### DIFF
--- a/src/Components/NewProjectPage/index.js
+++ b/src/Components/NewProjectPage/index.js
@@ -260,8 +260,10 @@ export default class NewProjectPage extends React.Component {
   render() {
     return (
       <div>
-        <div className="row">
-          <h2>Baseline Editor</h2>
+        <div className="title-container">
+          <div className="row">
+            <h2>Baseline Editor</h2>
+          </div>
         </div>
         {this.renderMandatoryWarning()}
         {this.renderSuccessOrForm()}

--- a/src/Components/NewProjectPage/style.css
+++ b/src/Components/NewProjectPage/style.css
@@ -15,3 +15,7 @@
 .no-edge {
   margin: 0px;
 }
+
+.title-container {
+  padding-left: 30px;
+}


### PR DESCRIPTION
Was going of the screen a bit: 
<img width="1387" alt="screen shot 2018-12-06 at 09 36 14" src="https://user-images.githubusercontent.com/38878719/49575460-9fd8b900-f93a-11e8-9f98-20b5a436462d.png">
Now it's not:
<img width="1389" alt="screen shot 2018-12-06 at 09 35 17" src="https://user-images.githubusercontent.com/38878719/49575459-9f402280-f93a-11e8-8e89-dfc7673291aa.png">

