### PR TITLE
Don't display a number if there is no title for sidebar items.

### DIFF
--- a/src/UseCase/GenerateSidebarItems/generateSidebarItems.test.js
+++ b/src/UseCase/GenerateSidebarItems/generateSidebarItems.test.js
@@ -274,5 +274,34 @@ describe("GenerateSidebarItems", () => {
         });
       });
     });
+
+    describe("With no title", () => {
+      it("Generates a single sidebar item with an empty string for a ittle", () => {
+        let schema = {
+          type: "array",
+          items: {
+            title: "",
+            type: "object",
+            properties: {
+              noise: {
+                title: "Noise"
+              }
+            }
+          }
+        };
+        let data = [{}];
+        let response = useCase.execute(schema, data);
+        expect(response).toEqual({
+          items: {
+            0: {
+              title: "",
+              children: {
+                noise: { title: "Noise", index : 0, subSection: 'noise' }
+              }
+            }
+          }
+        });
+      });
+    });
   });
 });

--- a/src/UseCase/GenerateSidebarItems/index.js
+++ b/src/UseCase/GenerateSidebarItems/index.js
@@ -16,12 +16,20 @@ export default class GenerateSidebarItems {
     
     data.forEach((_, i) => {
       items[i] = {
-        title: `${schema.items.title} ${i + 1}`,
+        title: this.generateTitle(schema.items.title, i),
         children: this.genreateItemsForChildren(schema, i)
       };
     });
 
     return items;
+  }
+
+  generateTitle(title, index) {
+    if(title) {
+      return `${title} ${index + 1}`
+    } else {
+      return ""
+    }
   }
 
   genreateItemsForChildren(schema, index) {


### PR DESCRIPTION
WHY: We use arrays to split up tabs it's different pages. When the data isn't actually supposed to be an array we don't want to display the numbers.