### PR TITLE
Hide baseline variance field if not delayed

### DIFF
--- a/src/Components/VarianceField/index.js
+++ b/src/Components/VarianceField/index.js
@@ -33,12 +33,20 @@ export default class VarianceField extends React.Component {
     });
   };
 
-  renderBaselineVariance = () => (
-    <div className="col-md-3 form-group">
-      <label>Baseline Variance (weeks)</label>
-      <p data-test="baseline-variance">{this.state.baselineVariance || 0}</p>
-    </div>
-  );
+  renderBaselineVariance = () => {
+    if (this.state.status === "Delayed") {
+      return (
+        <div className="col-md-3 form-group">
+          <label>Baseline Variance (weeks)</label>
+          <p data-test="baseline-variance">
+            {this.state.baselineVariance || 0}
+          </p>
+        </div>
+      );
+    } else {
+      return;
+    }
+  };
 
   renderReturnVariance() {
     if (this.state.previousReturn !== undefined) {

--- a/src/Components/VarianceField/varianceField.test.js
+++ b/src/Components/VarianceField/varianceField.test.js
@@ -48,7 +48,7 @@ describe("VarianceField", () => {
 
       it("Renders the baseline variance field", () => {
         let baselineVariance = field.find("[data-test='baseline-variance']");
-        expect(baselineVariance.length).toEqual(1);
+        expect(baselineVariance.length).toEqual(0);
       });
 
       it("Renders the return variance field", () => {
@@ -137,7 +137,7 @@ describe("VarianceField", () => {
 
       it("Renders the baseline variance field", () => {
         let baselineVariance = field.find("[data-test='baseline-variance']");
-        expect(baselineVariance.length).toEqual(1);
+        expect(baselineVariance.length).toEqual(0);
       });
 
       it("Renders the return variance field", () => {
@@ -266,6 +266,11 @@ describe("VarianceField", () => {
           expect(status).toEqual("Delayed");
         });
 
+        it("Renders the baseline variance field", () => {
+          let baselineVariance = field.find("[data-test='baseline-variance']");
+          expect(baselineVariance.length).toEqual(1);
+        });
+
         it("Fills in the updated value", () => {
           let updatedValue = field
             .find("[data-test='variance-current']")
@@ -304,6 +309,11 @@ describe("VarianceField", () => {
           let status = field.find("[data-test='variance-status']").props()
             .value;
           expect(status).toEqual("Delayed");
+        });
+
+        it("Renders the baseline variance field", () => {
+          let baselineVariance = field.find("[data-test='baseline-variance']");
+          expect(baselineVariance.length).toEqual(1);
         });
 
         it("Fills in the updated value", () => {


### PR DESCRIPTION
Not necessary for this field to be displayed unless the variance is delayed