### PR TITLE
Change return of null to return of undefined.

### DIFF
--- a/src/Components/CalculatedField/index.js
+++ b/src/Components/CalculatedField/index.js
@@ -129,7 +129,6 @@ export default class CalculatedField extends React.Component {
   };
 
   render = () => {
-    console.log(this.state.formData)
     return (
       <this.props.registry.fields.SchemaField
         formData={this.state.formData}

--- a/src/Components/CalculatedField/index.js
+++ b/src/Components/CalculatedField/index.js
@@ -21,52 +21,59 @@ function sum(data, ...keys) {
 }
 
 function periodTotal(object, totalPath, property, ...keys) {
-  if(!object[property]) return;
+  if (!object[property]) return;
   return object[property].forEach((value, index) => {
-    setCreate(object[property][index], totalPath, ""+sum(value, keys));
-    return (sum(value, keys));
+    setCreate(object[property][index], totalPath, "" + sum(value, keys));
+    return sum(value, keys);
   });
 }
 
 function weeksPassed(originalDate, newDate) {
-  let seconds = secondsPassed(originalDate, newDate)
-  return Math.round(seconds/(7 * 60 * 60 * 24));
+  let seconds = secondsPassed(originalDate, newDate);
+  return Math.round(seconds / (7 * 60 * 60 * 24));
 }
 
 function daysPassed(originalDate, newDate) {
-  let seconds = secondsPassed(originalDate, newDate)
-  return Math.round(seconds/(60 * 60 * 24));
+  let seconds = secondsPassed(originalDate, newDate);
+  return Math.round(seconds / (60 * 60 * 24));
 }
 
 function secondsPassed(originalDate, newDate) {
   let originalDateDatified = new Date(originalDate);
   let newDateDatified = new Date(newDate);
 
-  if(newDateDatified == 'Invalid Date' || originalDateDatified == 'Inavlid Date') return ""
+  if (
+    newDateDatified == "Invalid Date" ||
+    originalDateDatified == "Inavlid Date"
+  )
+    return "";
 
-  return (newDateDatified - originalDateDatified) / 1000
+  return (newDateDatified - originalDateDatified) / 1000;
 }
 
 function validateArrayPropertyIsLessThan(array, path, value) {
-  array.forEach((object) => {
-    setCreate(object, [...path.slice(0, path.length-1), '_valid'], get(object, ...path) <= value);
+  array.forEach(object => {
+    setCreate(
+      object,
+      [...path.slice(0, path.length - 1), "_valid"],
+      get(object, ...path) <= value
+    );
   });
 }
 
 function setCreate(object, path, value) {
-  let jsonToSet = path.slice(0,path.length-1).reduce(
-    (accumulator, property) => {
+  let jsonToSet = path
+    .slice(0, path.length - 1)
+    .reduce((accumulator, property) => {
       if (accumulator[property]) {
         return accumulator[property];
       } else {
-        accumulator[property] = {}
+        accumulator[property] = {};
         return accumulator[property];
       }
-    },
-    object
-  );
+    }, object);
 
-  jsonToSet[path[path.length-1]] = value;
+  jsonToSet[path[path.length - 1]] = value;
   return object;
 }
 
@@ -75,17 +82,13 @@ function set(object, property, value) {
 }
 
 function get(object, ...properties) {
-  return properties.reduce(
-    (accumulator, property) => {
-      if (accumulator && accumulator[property])
-      {
-        return accumulator[property];
-      } else {
-        return null;
-      }
-    },
-    object
-  );
+  return properties.reduce((accumulator, property) => {
+    if (accumulator && accumulator[property]) {
+      return accumulator[property];
+    } else {
+      return undefined;
+    }
+  }, object);
 }
 
 function calculateVariance(value1, value2) {
@@ -97,8 +100,8 @@ function calculateVariance(value1, value2) {
 function combineArrays(array1, array2) {
   if (!array1) return array2;
   if (!array2) return array1;
-  return array1.concat(array2)
-};
+  return array1.concat(array2);
+}
 
 export default class CalculatedField extends React.Component {
   constructor(props) {
@@ -125,13 +128,16 @@ export default class CalculatedField extends React.Component {
     return uiSchema;
   };
 
-  render = () => (
-    <this.props.registry.fields.SchemaField
-      formData={this.state.formData}
-      schema={this.props.schema}
-      onChange={this.onChange}
-      uiSchema={this.removeCalculationBeforeRender(this.props.uiSchema)}
-      registry={this.props.registry}
-    />
-  );
+  render = () => {
+    console.log(this.state.formData)
+    return (
+      <this.props.registry.fields.SchemaField
+        formData={this.state.formData}
+        schema={this.props.schema}
+        onChange={this.onChange}
+        uiSchema={this.removeCalculationBeforeRender(this.props.uiSchema)}
+        registry={this.props.registry}
+      />
+    );
+  };
 }


### PR DESCRIPTION
Resolves an error that was occurring when `get()` was calling something undefined.