### PR TITLE
Fix GenerateUISchema overwriting while merging dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@amory/merge": {
+      "version": "2018.10.8-2",
+      "resolved": "https://registry.npmjs.org/@amory/merge/-/merge-2018.10.8-2.tgz",
+      "integrity": "sha512-eAd6KOPUX8GQIpRLTK14hJIwIKYe4nnBf14hJJv7AmjtU0EqwArcvmBH4tXhOq7VJ75c/ArCdwdXOrRsHxNuHw=="
+    },
     "@babel/code-frame": {
       "version": "7.0.0-beta.51",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@amory/merge": "^2018.10.8-2",
     "@mars/heroku-js-runtime-env": "^3.0.2",
     "clipboard": "^2.0.1",
     "core-js": "^2.6.1",

--- a/src/UseCase/GenerateUISchema/generateUISchema.test.js
+++ b/src/UseCase/GenerateUISchema/generateUISchema.test.js
@@ -922,6 +922,131 @@ describe("GenerateUISchema", () => {
   });
 
   describe("With Dependencies", () => {
+    describe("At multiple levels", () => {
+      it("Sets the UI schema for dependencies", () => {
+        let schema = {
+          type: "object",
+          properties: {
+            widerScheme: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  topRisks: {
+                    type: "object",
+                    properties: {
+                      landAssembly: {
+                        type: "object",
+                        properties: {
+                          riskHolder: {
+                            type: "object",
+                            properties: {
+                              liveRisk: {
+                                type: "string",
+                                radio: true
+                              }
+                            },
+                            dependencies: {
+                              liveRisk: {
+                                oneOf: [
+                                  {
+                                    properties: {
+                                      liveRisk: {
+                                        type: "string",
+                                        radio: true
+                                      },
+                                      description: {
+                                        type: "string",
+                                        extendedText: true,
+                                      }
+                                    }
+                                  },
+                                  {
+                                    properties: {
+                                      liveRisk: {
+                                        type: "string",
+                                        radio: true
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        dependencies: {
+                          riskHolder: {
+                            oneOf: [
+                              {
+                                properties: {
+                                  riskHolder: {
+                                    type: "object",
+                                    properties: {
+                                      liveRisk: {
+                                        type: "string",
+                                        radio: true
+                                      },
+                                      description: {
+                                        type: "string",
+                                        extendedText: true,
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                properties: {
+                                  riskHolder: {
+                                    type: "object",
+                                    properties: {
+                                      liveRisk: {
+                                        type: "string",
+                                        radio: true
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        let response = useCase.execute(schema);
+
+        expect(response).toEqual({
+          "widerScheme": {
+            "items": {
+              "topRisks": {
+                "landAssembly": {
+                  "riskHolder": {
+                    "liveRisk": {
+                      "ui:widget": "radio"
+                    },
+                    "description": {
+                      "ui:widget": "textarea"
+                    }
+                  }
+                }
+              }
+            },
+            "ui:options": {
+              "addable": false,
+              "orderable": false,
+              "removable": false
+            }
+          }
+        });
+      });
+    });
+
     describe("With a single dependency", () => {
       describe("Inside an object", () => {
         describe("Example one", () => {

--- a/src/UseCase/GenerateUISchema/index.js
+++ b/src/UseCase/GenerateUISchema/index.js
@@ -1,3 +1,5 @@
+import merge from "@amory/merge";
+
 export default class GenerateUISchema {
   constructor(userRoleCookieGateway) {
     this.userRoleGateway = userRoleCookieGateway;
@@ -36,7 +38,7 @@ export default class GenerateUISchema {
 
     if (value.dependencies) {
       let dependencySchema = this.generateSchemaForDependencies(value, role);
-      ret = this.mergeObjects(ret, dependencySchema);
+      ret = merge(ret, dependencySchema);
     }
 
     return ret;
@@ -82,7 +84,7 @@ export default class GenerateUISchema {
 
   generateSchemaForDependencies(value, role) {
     let reducer = (acc, dependency) =>
-      this.mergeObjects(acc, this.generateSchemaForObject(dependency, role));
+      merge(acc, this.generateSchemaForObject(dependency, role));
 
     let dependencies = Object.values(value.dependencies)[0];
     return dependencies.oneOf.reduce(reducer, {});
@@ -148,10 +150,6 @@ export default class GenerateUISchema {
 
   isAddableArray(arr) {
     return arr.addable ? true : false;
-  }
-
-  mergeObjects(one, two) {
-    return { ...one, ...two };
   }
 
   getUIFieldForObject(obj) {


### PR DESCRIPTION
Why - This bug was preventing 'description of risk' in the wider scheme tab from being shown as a textarea.