### PR TITLE
Prevent IE from making textarea too small

### DIFF
--- a/src/Components/ParentForm/style.css
+++ b/src/Components/ParentForm/style.css
@@ -1,3 +1,7 @@
+textarea {
+  min-height: 5em;
+}
+
 .subform-selectors {
   background: white;
   border-bottom: 1px solid black;


### PR DESCRIPTION
Before:
![capture](https://user-images.githubusercontent.com/41294831/51598113-b344e100-1ef4-11e9-90fe-eab6a9347e1e.PNG)  

After:
![capture](https://user-images.githubusercontent.com/41294831/51597992-7c6ecb00-1ef4-11e9-8d54-19ffa2c43f1f.PNG)
