### PR TITLE
Remove btn-block class

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -94,7 +94,7 @@ const renderReturnPage = props => (
 const CreateReturnButton = props => (
   <button
     data-test="new-return-button"
-    className="btn btn-primary btn-block"
+    className="btn btn-primary"
     onClick={() =>
       props.history.push(`/project/${props.match.params.id}/return`)
     }


### PR DESCRIPTION
On lower resolution or less wide screens, the create new return button had its text cut off.
The removal of this class resolves this issue.