### PR TITLE
Add tests and early return for edge cases where path is undefined

### DIFF
--- a/src/Components/CalculatedField/calculations.test.js
+++ b/src/Components/CalculatedField/calculations.test.js
@@ -23,28 +23,82 @@ import {
 describe("setArrayField", () => {
   describe("Passes items which aren't arrays", () => {
     it("Returns null", () => {
-      let newArray
-      setArrayField(null, ['property'], newArray, ['property'])
+      let newArray;
+      setArrayField(null, ["property"], newArray, ["property"]);
       expect(newArray).toBeUndefined();
     });
 
     it("Returns null", () => {
-      let newArray
-      setArrayField({someObject: "What? this isnt supposed to be an object"}, ['property'], newArray, ['property'])
+      let newArray;
+      setArrayField(
+        { someObject: "What? this isnt supposed to be an object" },
+        ["property"],
+        newArray,
+        ["property"]
+      );
       expect(newArray).toBeUndefined();
     });
   });
 
-  it("Example 1",() => {
-    let array = [{ property1: "1", property2: "2" }, { property1: "3", property2: "4" }]
-    let newArray = setArrayField(array, ['property1'], undefined, ['differentproperty1'])
-    expect(newArray).toEqual([{ differentproperty1: "1"}, { differentproperty1: "3"}])
+  describe("Returns early without an error when field paths return undefined", () => {
+    it("Example 1", () => {
+      let array = [
+        { property1: "1", property2: "2" },
+        { property1: "3", property2: "4" }
+      ];
+      let newArray = setArrayField(
+        array,
+        undefined,
+        [{ anUnrelatedProperty: "5" }],
+        ["property1"]
+      );
+      expect(newArray).toBeUndefined();
+    });
+
+    it("Example 2", () => {
+      let array = [
+        { property1: "1", property2: "2" },
+        { property1: "3", property2: "4" }
+      ];
+      let newArray = setArrayField(
+        array,
+        ["property1"],
+        [{ anUnrelatedProperty: "5" }],
+        undefined
+      );
+      expect(newArray).toBeUndefined();
+    });
   });
 
-  it("Example 2",() => {
-    let array = [{ property1: "1", property2: "2" }, { property1: "3", property2: "4" }]
-    let newArray = setArrayField(array, ['property1'], [{anUnrelatedProperty: "5"}], ['property1'])
-    expect(newArray).toEqual([{ property1: "1", anUnrelatedProperty: "5"}, { property1: "3"}])
+  it("Example 1", () => {
+    let array = [
+      { property1: "1", property2: "2" },
+      { property1: "3", property2: "4" }
+    ];
+    let newArray = setArrayField(array, ["property1"], undefined, [
+      "differentproperty1"
+    ]);
+    expect(newArray).toEqual([
+      { differentproperty1: "1" },
+      { differentproperty1: "3" }
+    ]);
+  });
+
+  it("Example 2", () => {
+    let array = [
+      { property1: "1", property2: "2" },
+      { property1: "3", property2: "4" }
+    ];
+    let newArray = setArrayField(
+      array,
+      ["property1"],
+      [{ anUnrelatedProperty: "5" }],
+      ["property1"]
+    );
+    expect(newArray).toEqual([
+      { property1: "1", anUnrelatedProperty: "5" },
+      { property1: "3" }
+    ]);
   });
 });
 
@@ -56,14 +110,20 @@ describe("filterForNos()", () => {
   describe("With data", () => {
     it("Example 1", () => {
       expect(
-        filterForNos([{a: {b:"Yes"}, b: "we"}, {a: {b: "No"}, b: "e"}], ['a','b'])
-      ).toEqual([{a: {b: "No"}, b: "e"}]);
+        filterForNos(
+          [{ a: { b: "Yes" }, b: "we" }, { a: { b: "No" }, b: "e" }],
+          ["a", "b"]
+        )
+      ).toEqual([{ a: { b: "No" }, b: "e" }]);
     });
 
     it("Example 2", () => {
       expect(
-        filterForNos([{en: "Yes", gb: true}, {en: "Yes"}, {en: "No", gb: true}], ['en'])
-      ).toEqual([{en: "No", gb: true}]);
+        filterForNos(
+          [{ en: "Yes", gb: true }, { en: "Yes" }, { en: "No", gb: true }],
+          ["en"]
+        )
+      ).toEqual([{ en: "No", gb: true }]);
     });
   });
 });
@@ -345,7 +405,9 @@ describe("periodTotal()", () => {
     });
 
     it("Example 2", () => {
-      let formData = { per: [{ Q3: "12", Q4: "8.111" }, { Q3: "32.333", Q4: "16" }] };
+      let formData = {
+        per: [{ Q3: "12", Q4: "8.111" }, { Q3: "32.333", Q4: "16" }]
+      };
       periodTotal(formData, ["value"], "per", "Q3", "Q4");
       expect(formData).toEqual({
         per: [

--- a/src/Components/CalculatedField/index.js
+++ b/src/Components/CalculatedField/index.js
@@ -2,9 +2,8 @@ import "../../Polyfills/Array/flat";
 import React from "react";
 
 export function filterForNos(array, path) {
-  if (array)
-  {
-    return array.filter((i) => get(i, ...path) === "No")
+  if (array) {
+    return array.filter(i => get(i, ...path) === "No");
   }
   return [];
 }
@@ -18,7 +17,7 @@ export function parseMoney(value) {
 }
 
 export function accumulateMoney(array, property) {
-  if(!array) return null;
+  if (!array) return null;
   return array
     .reduce((total, object) => parseMoney(object[property]) + total, 0)
     .toFixed(2);
@@ -98,12 +97,20 @@ export function validateArrayPropertyIsLessThan(array, path, value) {
   });
 }
 
-export function setArrayField(copyFromArray, copyFromFieldPath, copyToArray, copyToFieldPath) {
-  if(!copyFromArray || copyFromArray.constructor !== Array) return ;
+export function setArrayField(
+  copyFromArray,
+  copyFromFieldPath,
+  copyToArray,
+  copyToFieldPath
+) {
+  if (!copyFromArray || copyFromArray.constructor !== Array) return;
+  if (copyToFieldPath === undefined || copyFromFieldPath === undefined) {
+    return;
+  }
   copyFromArray.forEach((item, index) => {
-    if(!copyToArray) copyToArray = [{}];
-    if (copyToArray.length < index + 1 ) copyToArray.push({});
-    
+    if (!copyToArray) copyToArray = [{}];
+    if (copyToArray.length < index + 1) copyToArray.push({});
+
     let getValue = copyFromFieldPath.reduce((accumulator, property) => {
       if (accumulator && accumulator[property]) {
         return accumulator[property];
@@ -111,10 +118,10 @@ export function setArrayField(copyFromArray, copyFromFieldPath, copyToArray, cop
         return undefined;
       }
     }, item);
-    
-    setCreate(copyToArray[index], copyToFieldPath , getValue )
+
+    setCreate(copyToArray[index], copyToFieldPath, getValue);
   });
-  return copyToArray
+  return copyToArray;
 }
 
 export function setCreate(object, path, value) {

--- a/src/Components/CalculatedField/index.js
+++ b/src/Components/CalculatedField/index.js
@@ -104,23 +104,24 @@ export function setArrayField(
   copyToFieldPath
 ) {
   if (!copyFromArray || copyFromArray.constructor !== Array) return;
-  if (copyToFieldPath === undefined || copyFromFieldPath === undefined) {
+  try {
+    copyFromArray.forEach((item, index) => {
+      if (!copyToArray) copyToArray = [{}];
+      if (copyToArray.length < index + 1) copyToArray.push({});
+
+      let getValue = copyFromFieldPath.reduce((accumulator, property) => {
+        if (accumulator && accumulator[property]) {
+          return accumulator[property];
+        } else {
+          return undefined;
+        }
+      }, item);
+
+      setCreate(copyToArray[index], copyToFieldPath, getValue);
+    });
+  } catch (e) {
     return;
   }
-  copyFromArray.forEach((item, index) => {
-    if (!copyToArray) copyToArray = [{}];
-    if (copyToArray.length < index + 1) copyToArray.push({});
-
-    let getValue = copyFromFieldPath.reduce((accumulator, property) => {
-      if (accumulator && accumulator[property]) {
-        return accumulator[property];
-      } else {
-        return undefined;
-      }
-    }, item);
-
-    setCreate(copyToArray[index], copyToFieldPath, getValue);
-  });
   return copyToArray;
 }
 


### PR DESCRIPTION
WHAT:
try block has been wrapped around a function that can cause an exception when given undefined in certain arguments.

WHY:
Current implementation of setArrayFields has two arguments that are typically set by using the get function. However, in staging the get is returning undefined and causing the page to blow up.
This PR uses a try and catch block to return instead of blowing up the page.
(Seperate PR will be raised to correct the get call to return an actual path).