### PR TITLE
Adjust sequential date validation to ignore empty date fields

### DIFF
--- a/src/Components/CalculatedField/calculations.test.js
+++ b/src/Components/CalculatedField/calculations.test.js
@@ -428,6 +428,20 @@ describe("validateDatesSequential", () => {
     })
   });
 
+  describe("Empty but valid", () => {
+    it("Example 1", () => {
+      let formData = { date1: undefined, date2Holder: {date2: undefined}}
+      validateDatesSequential(formData, ["date1"], ["date2Holder", "date2"])
+      expect(formData).toEqual({ date1: undefined, date2Holder: {date2: undefined, _valid: true}})
+    })
+
+    it("Example 2", () => {
+      let formData = { date1: undefined, date2Holder: {date2: undefined}, date3Holder: {date3: undefined}}
+      validateDatesSequential(formData, ["date1"], ["date2Holder", "date2"], ["date3Holder", "date3"])
+      expect(formData).toEqual({ date1: undefined, date2Holder: {date2: undefined, _valid: true}, date3Holder: {date3: undefined, _valid: true}})
+    })
+  });
+
   describe("Invalid", () => {
     it("Example 1", () => {
       let formData = { date1: "2010-01-01", date2Holder: {date2: "2009-01-07"}}

--- a/src/Components/CalculatedField/index.js
+++ b/src/Components/CalculatedField/index.js
@@ -98,16 +98,19 @@ export function validateArrayPropertyIsLessThan(array, path, value) {
 }
 
 export function validateDatesSequential(object, ...dates) {
-  dates = dates.map(currentValue => [currentValue, new Date(get(object, currentValue))]);
-  
+  dates = dates.map(currentValue => [
+    currentValue,
+    (new Date(get(object, currentValue)))
+  ]);
+
   dates.forEach((dateInfo, index) => {
-    if (index === 0) return; 
-    setCreate(
-      object,
-      [...dateInfo[0].slice(0, dateInfo[0].length - 1), "_valid"],
-      dateInfo[1] >= dates[index - 1][1] 
-    )
-  })
+    if (index === 0) return;
+
+    let key = dateInfo[0].slice(0, dateInfo[0].length - 1);
+    let valid = dateInfo[1] >= dates[index - 1][1] || dateInfo[1] == "Invalid Date";
+
+    setCreate(object, [...key, "_valid"], valid);
+  });
 }
 
 export function setArrayField(


### PR DESCRIPTION
Previously, the validator would flag fields that hadn't been completed yet.
Will now wait for the date field to be completed before showing validation warning.