### PR TITLE
Lockdown returns based on web route changes

### DIFF
--- a/src/Components/ReturnPage/index.js
+++ b/src/Components/ReturnPage/index.js
@@ -100,7 +100,7 @@ export default class ReturnPage extends React.Component {
     if (returnData.status === "Submitted") {
       uiSchema = this.props.generateSubmittedSchema.execute(returnData.schema);
     } else {
-      uiSchema = this.props.generateUISchema.execute(returnData.schema);
+      uiSchema = this.props.generateUISchema.execute(returnData.schema, returnData.no_of_previous_returns);
     }
 
     await this.setState({

--- a/src/Components/ReturnPage/returnPage.test.js
+++ b/src/Components/ReturnPage/returnPage.test.js
@@ -74,7 +74,8 @@ class getReturnStub {
             }
           }
         }
-      }
+      },
+      no_of_previous_returns: 7
     });
   }
 }
@@ -101,7 +102,8 @@ class getBaseReturnStub {
             }
           }
         }
-      }
+      },
+      no_of_previous_returns: 7
     });
   }
 }

--- a/src/Domain/Return/index.js
+++ b/src/Domain/Return/index.js
@@ -1,7 +1,8 @@
 export default class Return {
-  constructor(data, schema) {
+  constructor(data, schema, no_of_previous_returns) {
     this.data = data
     this.schema = schema
-  }  
+    this.no_of_previous_returns = no_of_previous_returns
+  }
 }
 

--- a/src/Gateway/ReturnGateway/index.js
+++ b/src/Gateway/ReturnGateway/index.js
@@ -36,7 +36,7 @@ export default class ReturnGateway {
 
     if (rawResponse.ok) {
       let jsonResponse = await rawResponse.json();
-      let foundReturn = new Return(jsonResponse.baseReturn.data, jsonResponse.baseReturn.schema);
+      let foundReturn = new Return(jsonResponse.baseReturn.data, jsonResponse.baseReturn.schema, jsonResponse.baseReturn.no_of_previous_returns);
       return {success: true, foundReturn};
     } else {
       return {success: false};

--- a/src/Gateway/ReturnGateway/returnGateway.test.js
+++ b/src/Gateway/ReturnGateway/returnGateway.test.js
@@ -303,7 +303,7 @@ describe("Return Gateway", () => {
             .matchHeader("Content-Type", "application/json")
             .get("/project/1/return")
             .reply(200, {
-              baseReturn: { data: { some: "data" }, schema: { some: "schema" } }
+              baseReturn: { data: { some: "data" }, schema: { some: "schema" }, no_of_previous_returns: 1 }
             });
           let gateway = new ReturnGateway(apiKeyGateway, locationGateway);
           response = await gateway.baseReturnFor(1);
@@ -317,6 +317,7 @@ describe("Return Gateway", () => {
           expect(response.success).toEqual(true);
           expect(response.foundReturn.data).toEqual({ some: "data" });
           expect(response.foundReturn.schema).toEqual({ some: "schema" });
+          expect(response.foundReturn.no_of_previous_returns).toEqual(1);
         });
       });
 
@@ -327,7 +328,7 @@ describe("Return Gateway", () => {
             .matchHeader("Content-Type", "application/json")
             .get("/project/5/return")
             .reply(200, {
-              baseReturn: { data: { cats: "meow" }, schema: { dogs: "woof" } }
+              baseReturn: { data: { cats: "meow" }, schema: { dogs: "woof" }, no_of_previous_returns: 7 }
             });
           let gateway = new ReturnGateway(apiKeyGateway, locationGateway);
           response = await gateway.baseReturnFor(5);
@@ -342,6 +343,7 @@ describe("Return Gateway", () => {
           expect(response.success).toEqual(true);
           expect(response.foundReturn.data).toEqual({ cats: "meow" });
           expect(response.foundReturn.schema).toEqual({ dogs: "woof" });
+          expect(response.foundReturn.no_of_previous_returns).toEqual(7);
         });
       });
     });

--- a/src/UseCase/GenerateDisabledUISchema/generateDisabledUISchema.test.js
+++ b/src/UseCase/GenerateDisabledUISchema/generateDisabledUISchema.test.js
@@ -153,7 +153,7 @@ describe("GenerateDisabledUISchema", () => {
       useCase = new GenerateDisabledUISchema(generateUISchemaSpy);
     });
 
-    fit("Calls the generateUISchema use case", () => {
+    it("Calls the generateUISchema use case", () => {
       useCase.execute({properties: {a: {}}});
       expect(generateUISchemaSpy.execute).toHaveBeenCalledWith({properties: {a: {}}});
     });
@@ -248,6 +248,10 @@ describe("GenerateDisabledUISchema", () => {
   });
 
   describe("With hidden fields", () => {
+    beforeEach(() => {
+      generateUISchemaSpy = {execute: jest.fn(() => ({a: {b: {"ui:widget": "widget"} }}))};
+      useCase = new GenerateDisabledUISchema(generateUISchemaSpy);
+    });
     describe("In an object", () => {
       describe("Example one", () => {
         it("Marks the field as hidden", () => {
@@ -290,6 +294,7 @@ describe("GenerateDisabledUISchema", () => {
           };
           let response = useCase.execute(schema);
           expect(response).toEqual({
+            a: { b: { "ui:widget": "widget" } },
             c: { d: { "ui:widget": "hidden" } },
             e: { f: { "ui:widget": "hidden" } }
           });
@@ -332,7 +337,8 @@ describe("GenerateDisabledUISchema", () => {
             a: {
               cats: { "ui:disabled": true },
               meow: { cat: { "ui:widget": "hidden" } },
-              quack: { "ui:disabled": true }
+              quack: { "ui:disabled": true },
+              b: { "ui:widget": "widget" }
             }
           });
         });

--- a/src/UseCase/GenerateUISchema/generateUISchema.test.js
+++ b/src/UseCase/GenerateUISchema/generateUISchema.test.js
@@ -146,9 +146,10 @@ describe("GenerateUISchema", () => {
       });
     });
   });
+
   describe("Readonly", () => {
     describe("Example one", () => {
-      it("Generates a ui schema from a single field", () => {
+        it("Generates a ui schema from a single field", () => {
         let useCase = new GenerateUISchema(userRoleCookieGateway);
         let schema = {
           type: "object",
@@ -369,6 +370,246 @@ describe("GenerateUISchema", () => {
         let response = useCase.execute(schema);
         expect(response).toEqual({
           d: { e: { "ui:disabled": true } }
+        });
+      });
+    });
+  });
+
+  describe("Readonly after certain number of returns", () => {
+    describe("Example one", () => {
+      it("Generates no disabled ui schema for a valid number of returns", () => {
+        let useCase = new GenerateUISchema(userRoleCookieGateway);
+        let schema = {
+          type: "object",
+          properties: {
+            a: { type: "string", readonly: 4 }
+          }
+        };
+        let noOfPreviousReturns = 2
+        let response = useCase.execute(schema, noOfPreviousReturns);
+        expect(response).toEqual({});
+      });
+
+      it("Generates a ui schema for an invalid number of returns", () => {
+        let useCase = new GenerateUISchema(userRoleCookieGateway);
+        let schema = {
+          type: "object",
+          properties: {
+            a: { type: "string", readonly: 2 }
+          }
+        };
+        let noOfPreviousReturns = 4
+        let response = useCase.execute(schema, noOfPreviousReturns);
+        expect(response).toEqual({a: {"ui:disabled": true}});
+      });
+
+      it("Generates a ui schema for the same number of returns", () => {
+        let useCase = new GenerateUISchema(userRoleCookieGateway);
+        let schema = {
+          type: "object",
+          properties: {
+            a: { type: "string", readonly: 1 }
+          }
+        };
+        let noOfPreviousReturns = 1
+        let response = useCase.execute(schema, noOfPreviousReturns);
+        expect(response).toEqual({a: {"ui:disabled": true}});
+      });
+
+      it("Generates the correct ui schema with different types of readonly fields", () => {
+        let useCase = new GenerateUISchema(userRoleCookieGateway);
+        let schema = {
+          type: "object",
+          properties: {
+            a: {
+              type: "object",
+              properties: {
+                c: { type: "string" },
+                d: { type: "string", readonly: 4 }
+              }
+            },
+            b: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  e: { type: "string", readonly: true },
+                  f: { type: "string" }
+                }
+              }
+            }
+          }
+        };
+        let noOfPreviousReturns = 2
+        let response = useCase.execute(schema, noOfPreviousReturns);
+        expect(response).toEqual({
+          a: {},
+          b: {
+            "ui:options": {
+              addable: false,
+              orderable: false,
+              removable: false
+            },
+            items: { e: { "ui:disabled": true } }
+          }
+        });
+      });
+
+      it("Generates the correct ui schema with different types of readonly fields", () => {
+        let useCase = new GenerateUISchema(userRoleCookieGateway);
+        let schema = {
+          type: "object",
+          properties: {
+            a: {
+              type: "object",
+              properties: {
+                c: { type: "string" },
+                d: { type: "string", readonly: 2 }
+              }
+            },
+            b: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  e: { type: "string", readonly: true },
+                  f: { type: "string" }
+                }
+              }
+            }
+          }
+        };
+        let noOfPreviousReturns = 4
+        let response = useCase.execute(schema, noOfPreviousReturns);
+        expect(response).toEqual({
+          a: {d: {"ui:disabled": true}},
+          b: {
+            "ui:options": {
+              addable: false,
+              orderable: false,
+              removable: false
+            },
+            items: { e: { "ui:disabled": true } }
+          }
+        });
+      });
+    });
+
+    describe("Example two", () => {
+      it("Generates a disabled ui schema for a valid number of returns", () => {
+        let useCase = new GenerateUISchema(userRoleCookieGateway);
+        let schema = {
+          type: "object",
+          properties: {
+            a: { type: "string", readonly: 4 }
+          }
+        };
+        let noOfPreviousReturns = 2
+        let response = useCase.execute(schema, noOfPreviousReturns);
+        expect(response).toEqual({});
+      });
+
+      it("Generates a ui schema for an invalid number of returns", () => {
+        let useCase = new GenerateUISchema(userRoleCookieGateway);
+        let schema = {
+          type: "object",
+          properties: {
+            a: { type: "string", readonly: 6 }
+          }
+        };
+        let noOfPreviousReturns = 10
+        let response = useCase.execute(schema, noOfPreviousReturns);
+        expect(response).toEqual({a: {"ui:disabled": true}});
+      });
+
+      it("Generates a ui schema for the same number of returns", () => {
+        let useCase = new GenerateUISchema(userRoleCookieGateway);
+        let schema = {
+          type: "object",
+          properties: {
+            a: { type: "string", readonly: 5 }
+          }
+        };
+        let noOfPreviousReturns = 5
+        let response = useCase.execute(schema, noOfPreviousReturns);
+        expect(response).toEqual({a: {"ui:disabled": true}});
+      });
+
+      it("Generates the correct ui schema with different types of readonly fields", () => {
+        let useCase = new GenerateUISchema(userRoleCookieGateway);
+        let schema = {
+          type: "object",
+          properties: {
+            a: {
+              type: "object",
+              properties: {
+                c: { type: "string" },
+                d: { type: "string", readonly: 5 }
+              }
+            },
+            b: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  e: { type: "string", readonly: true },
+                  f: { type: "string" }
+                }
+              }
+            }
+          }
+        };
+        let noOfPreviousReturns = 1
+        let response = useCase.execute(schema, noOfPreviousReturns);
+        expect(response).toEqual({
+          a: {},
+          b: {
+            "ui:options": {
+              addable: false,
+              orderable: false,
+              removable: false
+            },
+            items: { e: { "ui:disabled": true } }
+          }
+        });
+      });
+
+      it("Generates the correct ui schema with different types of readonly fields", () => {
+        let useCase = new GenerateUISchema(userRoleCookieGateway);
+        let schema = {
+          type: "object",
+          properties: {
+            a: {
+              type: "object",
+              properties: {
+                c: { type: "string" },
+                d: { type: "string", readonly: 5 }
+              }
+            },
+            b: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  e: { type: "string", readonly: true },
+                  f: { type: "string" }
+                }
+              }
+            }
+          }
+        };
+        let noOfPreviousReturns = 7
+        let response = useCase.execute(schema, noOfPreviousReturns);
+        expect(response).toEqual({
+          a: {d: {"ui:disabled": true}},
+          b: {
+            "ui:options": {
+              addable: false,
+              orderable: false,
+              removable: false
+            },
+            items: { e: { "ui:disabled": true } }
+          }
         });
       });
     });

--- a/src/UseCase/GenerateUISchema/generateUISchema.test.js
+++ b/src/UseCase/GenerateUISchema/generateUISchema.test.js
@@ -382,7 +382,7 @@ describe("GenerateUISchema", () => {
         let schema = {
           type: "object",
           properties: {
-            a: { type: "string", readonly: 4 }
+            a: { type: "string", readonly_after_return: 4 }
           }
         };
         let noOfPreviousReturns = 2
@@ -395,7 +395,7 @@ describe("GenerateUISchema", () => {
         let schema = {
           type: "object",
           properties: {
-            a: { type: "string", readonly: 2 }
+            a: { type: "string", readonly_after_return: 2 }
           }
         };
         let noOfPreviousReturns = 4
@@ -408,7 +408,7 @@ describe("GenerateUISchema", () => {
         let schema = {
           type: "object",
           properties: {
-            a: { type: "string", readonly: 1 }
+            a: { type: "string", readonly_after_return: 1 }
           }
         };
         let noOfPreviousReturns = 1
@@ -425,7 +425,7 @@ describe("GenerateUISchema", () => {
               type: "object",
               properties: {
                 c: { type: "string" },
-                d: { type: "string", readonly: 4 }
+                d: { type: "string", readonly_after_return: 4 }
               }
             },
             b: {
@@ -464,7 +464,7 @@ describe("GenerateUISchema", () => {
               type: "object",
               properties: {
                 c: { type: "string" },
-                d: { type: "string", readonly: 2 }
+                d: { type: "string", readonly_after_return: 2 }
               }
             },
             b: {
@@ -501,7 +501,7 @@ describe("GenerateUISchema", () => {
         let schema = {
           type: "object",
           properties: {
-            a: { type: "string", readonly: 4 }
+            a: { type: "string", readonly_after_return: 4 }
           }
         };
         let noOfPreviousReturns = 2
@@ -514,7 +514,7 @@ describe("GenerateUISchema", () => {
         let schema = {
           type: "object",
           properties: {
-            a: { type: "string", readonly: 6 }
+            a: { type: "string", readonly_after_return: 6 }
           }
         };
         let noOfPreviousReturns = 10
@@ -527,7 +527,7 @@ describe("GenerateUISchema", () => {
         let schema = {
           type: "object",
           properties: {
-            a: { type: "string", readonly: 5 }
+            a: { type: "string", readonly_after_return: 5 }
           }
         };
         let noOfPreviousReturns = 5
@@ -544,7 +544,7 @@ describe("GenerateUISchema", () => {
               type: "object",
               properties: {
                 c: { type: "string" },
-                d: { type: "string", readonly: 5 }
+                d: { type: "string", readonly_after_return: 5 }
               }
             },
             b: {
@@ -583,7 +583,7 @@ describe("GenerateUISchema", () => {
               type: "object",
               properties: {
                 c: { type: "string" },
-                d: { type: "string", readonly: 5 }
+                d: { type: "string", readonly_after_return: 5 }
               }
             },
             b: {

--- a/src/UseCase/GenerateUISchema/index.js
+++ b/src/UseCase/GenerateUISchema/index.js
@@ -4,22 +4,22 @@ export default class GenerateUISchema {
   constructor(userRoleCookieGateway) {
     this.userRoleGateway = userRoleCookieGateway;
   }
-  execute(data) {
+  execute(data, noOfPreviousReturns) {
     let userRole = this.userRoleGateway.getUserRole().userRole;
 
-    return this.generateUISchema(data.properties, userRole);
+    return this.generateUISchema(data.properties, userRole, noOfPreviousReturns);
   }
 
-  generateUISchema(data, role) {
+  generateUISchema(data, role, noOfPreviousReturns) {
     let ret = {};
 
     Object.entries(data).forEach(([key, value]) => {
       if (value.type === "object") {
-        ret[key] = this.generateSchemaForObject(value, role);
+        ret[key] = this.generateSchemaForObject(value, role, noOfPreviousReturns);
       } else if (value.type === "array") {
-        ret[key] = this.generateSchemaForArray(value, role);
+        ret[key] = this.generateSchemaForArray(value, role, noOfPreviousReturns);
       } else {
-        let itemSchema = this.generateSchemaForItem(value, role);
+        let itemSchema = this.generateSchemaForItem(value, role, noOfPreviousReturns);
         if (itemSchema) {
           ret[key] = itemSchema;
         }
@@ -28,8 +28,8 @@ export default class GenerateUISchema {
     return ret;
   }
 
-  generateSchemaForObject(value, role) {
-    let ret = this.generateUISchema(value.properties, role);
+  generateSchemaForObject(value, role, noOfPreviousReturns) {
+    let ret = this.generateUISchema(value.properties, role, noOfPreviousReturns);
     let uiField = this.getUIFieldForObject(value);
 
     if (uiField) {
@@ -37,14 +37,14 @@ export default class GenerateUISchema {
     }
 
     if (value.dependencies) {
-      let dependencySchema = this.generateSchemaForDependencies(value, role);
+      let dependencySchema = this.generateSchemaForDependencies(value, role, noOfPreviousReturns);
       ret = merge(ret, dependencySchema);
     }
 
     return ret;
   }
 
-  generateSchemaForArray(value, role) {
+  generateSchemaForArray(value, role, noOfPreviousReturns) {
     let ret = {};
     ret["ui:options"] = {
       addable: this.isAddableArray(value),
@@ -52,7 +52,7 @@ export default class GenerateUISchema {
       removable: this.isAddableArray(value)
     };
 
-    ret["items"] = this.generateUISchema(value.items.properties, role);
+    ret["items"] = this.generateUISchema(value.items.properties, role, noOfPreviousReturns);
 
     if (value.items.horizontal) {
       ret["items"]["ui:field"] = "horizontal";
@@ -82,15 +82,15 @@ export default class GenerateUISchema {
     return ret;
   }
 
-  generateSchemaForDependencies(value, role) {
+  generateSchemaForDependencies(value, role, noOfPreviousReturns) {
     let reducer = (acc, dependency) =>
-      merge(acc, this.generateSchemaForObject(dependency, role));
+      merge(acc, this.generateSchemaForObject(dependency, role, noOfPreviousReturns));
 
     let dependencies = Object.values(value.dependencies)[0];
     return dependencies.oneOf.reduce(reducer, {});
   }
 
-  generateSchemaForItem(item, role) {
+  generateSchemaForItem(item, role, noOfPreviousReturns) {
     let schema = {}
 
     if (item.extendedText) {
@@ -113,7 +113,7 @@ export default class GenerateUISchema {
       schema["ui:field"] = "uploadFile"
     }
 
-    if (item.readonly) {
+    if (item.readonly === true || item.readonly <= noOfPreviousReturns) {
       schema["ui:disabled"] = true
     }
 

--- a/src/UseCase/GenerateUISchema/index.js
+++ b/src/UseCase/GenerateUISchema/index.js
@@ -113,7 +113,11 @@ export default class GenerateUISchema {
       schema["ui:field"] = "uploadFile"
     }
 
-    if (item.readonly === true || item.readonly <= noOfPreviousReturns) {
+    if (item.readonly === true) {
+      schema["ui:disabled"] = true
+    }
+
+    if (item.readonly_after_return <= noOfPreviousReturns) {
       schema["ui:disabled"] = true
     }
 


### PR DESCRIPTION
Reliant on https://github.com/homes-england/monitor-api/pull/416

WHAT:
When setting a number in the readonly tag on the schema, the field will now lock after that number of returns have been submitted.