### PR TITLE
Authentication to depend on user

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import ReturnList from "./Components/ReturnList";
 import ReturnListProvider from "./Components/ReturnListProvider";
 import ReturnPage from "./Components/ReturnPage";
 import Portal from "./Components/Portal";
+import ProjectPortal from "./Components/ProjectPortal";
 import NotFound from "./Components/NotFound";
 import CookieConsent from "./Components/CookieConsent";
 import PrintReturn from "./Components/PrintReturn";
@@ -24,6 +25,7 @@ import GenerateDisabledUISchema from "./UseCase/GenerateDisabledUISchema";
 import GenerateUISchema from "./UseCase/GenerateUISchema";
 import GetBaseReturn from "./UseCase/GetBaseReturn";
 import CanAccessProject from "./UseCase/CanAccessProject";
+import CanAccessMonitor from "./UseCase/CanAccessMonitor";
 import GetProject from "./UseCase/GetProject";
 import GetReturn from "./UseCase/GetReturn";
 import GetReturns from "./UseCase/GetReturns"
@@ -68,6 +70,7 @@ const getBaseReturnUseCase = new GetBaseReturn(returnGateway);
 const getProjectUseCase = new GetProject(projectGateway);
 const getReturnUseCase = new GetReturn(returnGateway);
 const canAccessProjectUseCase = new CanAccessProject(tokenGateway, apiKeyGateway, userRoleGateway, projectGateway);
+const canAccessMonitorUseCase = new CanAccessMonitor(tokenGateway, apiKeyGateway, userRoleGateway);
 const getReturnsUseCase = new GetReturns(returnGateway);
 const requestTokenUseCase = new RequestToken(tokenGateway);
 const submitReturnUseCase = new SubmitReturn(returnGateway);
@@ -200,6 +203,12 @@ const renderPrintPage = props => (
    </PrintReturn>
 );
 
+const renderhomepage = props => (
+  <Homepage 
+
+  />
+)
+
 
 const App = () => (
   <Router>
@@ -208,55 +217,73 @@ const App = () => (
       <Header />
 
       <div className="monitor-container">
-        <Switch>
-          <Route exact path="/">
-            <Homepage />
-          </Route>
           <Route
-            path="/project/:id"
+            path="/"
             render={props => (
               <Portal
                 {...props}
-                projectId={props.match.params.id}
                 requestToken={requestTokenUseCase}
                 token={
                   qs.parse(props.location.search, { ignoreQueryPrefix: true })
                     .token
                 }
-                canAccessProject={canAccessProjectUseCase}
+                canAccessMonitor={canAccessMonitorUseCase}
               >
-                <Route
-                  exact
-                  path="/project/:id/new"
-                  render={renderNewProjectPage}
-                />
-                <Route exact path="/project/:id" render={renderProjectPage} />
-                <Route
-                  exact
-                  path="/project/:id/baseline"
-                  render={renderBaselinePage}
-                />
-                <Route
-                  exact
-                  path="/project/:projectId/return"
-                  render={renderReturnPage}
-                />
-                <Route
-                  exact
-                  path="/project/:projectId/return/:returnId"
-                  render={renderReturnPage}
-                />
-                <Route
-                  exact
-                  path="/project/:projectId/return/:returnId/print"
-                  render={renderPrintPage}
-                />
+                <Switch>
+                  <Route 
+                    exact
+                    path="/"
+                    render={renderhomepage}
+                  />
+                  <Route
+                    path="/project/:id"
+                    render={props => (
+                      <ProjectPortal
+                      {...props}
+                      url={props.match.url}
+                      projectId={props.match.params.id}
+                      canAccessProject={canAccessProjectUseCase}
+
+                      >
+                        <Route exact path="/project/:id" render={renderProjectPage} />
+                        <Route
+                          exact
+                          path="/project/:id/new"
+                          render={renderNewProjectPage}
+                        />
+                        <Route
+                          exact
+                          path="/project/:id/baseline"
+                          render={renderBaselinePage}
+                        />
+                        <Route
+                          exact
+                          path="/project/:projectId/return"
+                          render={renderReturnPage}
+                        />
+                        <Route
+                          exact
+                          path="/project/:projectId/return/:returnId"
+                          render={renderReturnPage}
+                        />
+                        <Route
+                          exact
+                          path="/project/:projectId/return/:returnId/print"
+                          render={renderPrintPage}
+                        />
+                      </ProjectPortal>
+                    )}
+                    />
+                  <Route
+                    path="*"
+                    exact={true}
+                    component={NotFound}
+                  />
+                </Switch>
               </Portal>
             )}
           />
 
-          <Route path="*" exact={true} component={NotFound} />
-        </Switch>
       </div>
 
       <Footer />

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -81,7 +81,7 @@ describe("Authentication against routes", () => {
   beforeEach(() => {
     process.env.REACT_APP_HIF_API_URL = "http://cat.meow/";
     api = new APISimulator("http://cat.meow");
-    api.expendEmptyTokenForProject(0).unauthorised();
+    api.expendEmptyTokenForProject().unauthorised();
     api.getProject({}, 0).unsuccessfully();
   });
 
@@ -127,7 +127,7 @@ describe("Viewing a project", () => {
   it("Given invalid token GetToken is shown", async () => {
     api.getProject({}, 0).unsuccessfully();
 
-    api.expendToken("Hello", 0).unauthorised();
+    api.expendToken("Hello").unauthorised();
 
     let page = new AppPage("/project/0?token=Hello");
     await page.load();
@@ -138,11 +138,11 @@ describe("Viewing a project", () => {
 
   describe("Given valid token", () => {
     beforeEach(() => {
-      api.expendToken("Cats", 0).successfully();
+      api.expendToken("Cats").successfully();
     });
 
     it("will not show GetToken", async () => {
-      api.expendToken("Cats", 0).successfully();
+      api.expendToken("Cats").successfully();
 
       api.getProject(projectSchema, projectData).successfully();
       api.getReturns({returns: []}).successfully();

--- a/src/Components/GetToken/getToken.test.js
+++ b/src/Components/GetToken/getToken.test.js
@@ -61,7 +61,7 @@ describe('GetToken', () => {
     page.submit()
     page.load()
 
-    expect(requestTokenSpy.execute).toHaveBeenCalledWith("cat@cathouse.com", "1", "http://localhost/")
+    expect(requestTokenSpy.execute).toHaveBeenCalledWith("cat@cathouse.com", "http://localhost/")
   });
 
   it("shows the 'sent' message when submitted", async () => {

--- a/src/Components/GetToken/index.js
+++ b/src/Components/GetToken/index.js
@@ -18,7 +18,6 @@ export default class GetToken extends React.Component {
     if (this.state.email) {
       this.props.requestToken.execute(
         this.state.email,
-        this.props.projectId,
         this.props.targetUrl
       );
       this.setState({ message_sent: true });

--- a/src/Components/Homepage/index.js
+++ b/src/Components/Homepage/index.js
@@ -7,6 +7,7 @@ export default class Homepage extends React.Component {
     super(props);
     this.env = runtimeEnv();
   }
+
   render() {
     return (
       <div className="row homepage">

--- a/src/Components/Portal/index.js
+++ b/src/Components/Portal/index.js
@@ -10,7 +10,7 @@ export default class Portal extends React.Component {
   }
 
   componentDidMount() {
-    this.props.canAccessProject.execute(this.props.token, parseInt(this.props.projectId, 10)).then(apiKey => this.setState({apiKey}))
+    this.props.canAccessMonitor.execute(this.props.token).then(apiKey => this.setState({apiKey}))
   }
 
   render() {

--- a/src/Components/Portal/portal.test.js
+++ b/src/Components/Portal/portal.test.js
@@ -68,7 +68,6 @@ describe("Portal", () => {
 
     expect(RequestTokenSpy.execute).toHaveBeenCalledWith(
       "cats@cathouse.com",
-      "1",
       "http://localhost/"
     );
   });

--- a/src/Components/Portal/portal.test.js
+++ b/src/Components/Portal/portal.test.js
@@ -12,7 +12,7 @@ async function updateFormField(input, value) {
 }
 
 describe("Portal", () => {
-  let CanAccessProjectSpy = {
+  let CanAccessMonitorSpy = {
     execute: jest.fn(async () => {
       return {
         valid: true,
@@ -25,19 +25,19 @@ describe("Portal", () => {
     execute: jest.fn()
   };
 
-  it("calls the CanAccessProject use case", async () => {
-    let wrapper = mount(
-      <Portal projectId="1" token="Cats" canAccessProject={CanAccessProjectSpy}>
+  it("calls the CanAccessMonitor use case", async () => {
+    mount(
+      <Portal token="Cats" canAccessMonitor={CanAccessMonitorSpy}>
         <div />
       </Portal>
     );
 
     await wait();
-    expect(CanAccessProjectSpy.execute).toHaveBeenCalledWith("Cats", 1);
+    expect(CanAccessMonitorSpy.execute).toHaveBeenCalledWith("Cats");
   });
 
   it("calls the requestToken use case", async () => {
-    CanAccessProjectSpy = {
+    CanAccessMonitorSpy = {
       execute: jest.fn(async () => {
         return {
           valid: false
@@ -46,9 +46,8 @@ describe("Portal", () => {
     };
     let wrapper = mount(
       <Portal
-        projectId="1"
         token="Cats"
-        canAccessProject={CanAccessProjectSpy}
+        canAccessMonitor={CanAccessMonitorSpy}
         requestToken={RequestTokenSpy}
       >
         <div />
@@ -73,7 +72,7 @@ describe("Portal", () => {
   });
 
   it("shows getToken if use case returns false", async () => {
-    CanAccessProjectSpy = {
+    CanAccessMonitorSpy = {
       execute: jest.fn(async () => {
         return {
           valid: false
@@ -82,9 +81,8 @@ describe("Portal", () => {
     };
     let wrapper = mount(
       <Portal
-        projectId="1"
         token="Cats"
-        canAccessProject={CanAccessProjectSpy}
+        canAccessMonitor={CanAccessMonitorSpy}
       />
     );
     await wait();
@@ -93,7 +91,7 @@ describe("Portal", () => {
   });
 
   it("renders children if the use case returns true", async () => {
-    CanAccessProjectSpy = {
+    CanAccessMonitorSpy = {
       execute: jest.fn(async () => {
         return {
           valid: true,
@@ -103,7 +101,7 @@ describe("Portal", () => {
     };
 
     let wrapper = mount(
-      <Portal projectId="1" token="Cats" canAccessProject={CanAccessProjectSpy}>
+      <Portal token="Cats" canAccessMonitor={CanAccessMonitorSpy}>
         <h1>Hiya!</h1>
       </Portal>
     );

--- a/src/Components/ProjectPortal/index.js
+++ b/src/Components/ProjectPortal/index.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import "../Homepage/style.css";
+import runtimeEnv from "@mars/heroku-js-runtime-env";
+
+export default class Portal extends React.Component {
+  constructor(props) {
+    super(props)
+    this.env = runtimeEnv();
+    this.state = {
+      apiKey: null
+    }
+  }
+
+  componentDidMount() {
+    this.props.canAccessProject.execute(this.props.token, parseInt(this.props.projectId, 10)).then(apiKey => this.setState({apiKey}))
+  }
+
+  renderBackToHomepageButton() {
+    return <button
+      data-test="back-to-homepage"
+      className="btn btn-link btn-lg"
+      onClick={() => this.props.history.push(`/`)}
+    >
+      Take me back to the Homepage
+    </button>
+  }
+
+  render() {
+    if (this.state.apiKey === null) {
+      return <div>Loading</div>
+    } else {
+      if (this.state.apiKey.valid) {
+        return this.props.children
+      } else {
+        return <div>
+          <div className="row homepage">
+        <div className="col-md-2" />
+        <div className="col-md-8">
+          <h1>Homes England Monitor</h1>
+          <p>
+            Welcome to the Homes England monitoring system. You are not a member of this project. If you believe you should have access
+            to this project, or have any feedback or queries please feel free to email{" "}
+            <a href={"mailto:" + this.env.REACT_APP_SUPPORT_EMAIL}>
+              {this.env.REACT_APP_SUPPORT_EMAIL}
+            </a>
+            .
+          </p>
+          {this.renderBackToHomepageButton()}
+        </div>
+        <div className="col-md-2" />
+      </div>
+      </div>
+      }
+    }
+  }
+}

--- a/src/Components/ProjectPortal/projectPortal.test.js
+++ b/src/Components/ProjectPortal/projectPortal.test.js
@@ -1,0 +1,73 @@
+import React from "react";
+import ProjectPortal from ".";
+import { mount } from "enzyme";
+
+async function wait() {
+  await new Promise(resolve => setTimeout(resolve, 100));
+}
+
+describe("ProjectPortal", () => {
+  let CanAccessProjectSpy = {
+    execute: jest.fn(async () => {
+      return {
+        valid: true,
+        apiKey: "Dogs"
+      };
+    })
+  };
+
+  let RequestTokenSpy = {
+    execute: jest.fn()
+  };
+
+  it("calls the CanAccessProject use case", async () => {
+    let wrapper = mount(
+      <ProjectPortal projectId="1" token="Cats" canAccessProject={CanAccessProjectSpy}>
+        <div />
+      </ProjectPortal>
+    );
+
+    await wait();
+    expect(CanAccessProjectSpy.execute).toHaveBeenCalledWith("Cats", 1);
+  });
+
+  it("shows a button back to homepage if use case returns false", async () => {
+    CanAccessProjectSpy = {
+      execute: jest.fn(async () => {
+        return {
+          valid: false
+        };
+      })
+    };
+    let wrapper = mount(
+      <ProjectPortal
+        projectId="1"
+        token="Cats"
+        canAccessProject={CanAccessProjectSpy}
+      />
+    );
+    await wait();
+    wrapper.update();
+    expect(wrapper.find('[data-test="back-to-homepage"]').length).toEqual(1);
+  });
+
+  it("renders children if the use case returns true", async () => {
+    CanAccessProjectSpy = {
+      execute: jest.fn(async () => {
+        return {
+          valid: true,
+          apiKey: "Cows"
+        };
+      })
+    };
+
+    let wrapper = mount(
+      <ProjectPortal projectId="1" token="Cats" canAccessProject={CanAccessProjectSpy}>
+        <h1>Hiya!</h1>
+      </ProjectPortal>
+    );
+    await wait();
+    wrapper.update();
+    expect(wrapper.find("GetToken").length).toEqual(0);
+  });
+});

--- a/src/Gateway/TokenGateway/index.js
+++ b/src/Gateway/TokenGateway/index.js
@@ -8,24 +8,24 @@ export default class TokenGateway {
     this.env = runtimeEnv()
   }
 
-  async requestToken(email_address, project_id, url) {
+  async requestToken(email_address, url) {
     await fetch(
       `${this.env.REACT_APP_HIF_API_URL}token/request`,
       {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({email_address, project_id, url}),
+        body: JSON.stringify({email_address, url}),
       },
     );
   }
 
-  async getAccess(access_token, project_id) {
+  async getAccess(access_token) {
     let response = await fetch(
       `${this.env.REACT_APP_HIF_API_URL}token/expend`,
       {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({access_token, project_id}),
+        body: JSON.stringify({access_token}),
       },
     );
 

--- a/src/Gateway/TokenGateway/tokenGateway.test.js
+++ b/src/Gateway/TokenGateway/tokenGateway.test.js
@@ -11,10 +11,10 @@ describe('token gateway', () => {
         process.env.REACT_APP_HIF_API_URL = 'http://cat.meow/';
         let accessInfoRequest = nock('http://cat.meow')
           .matchHeader('Content-Type', 'application/json')
-          .post('/token/request', {email_address: 'cats@cathouse.com', project_id: 1})
+          .post('/token/request', {email_address: 'cats@cathouse.com'})
           .reply(200);
         let gateway = new TokenGateway();
-        await gateway.requestToken('cats@cathouse.com', 1);
+        await gateway.requestToken('cats@cathouse.com');
         expect(accessInfoRequest.isDone()).toBeTruthy()
       })
     })
@@ -24,10 +24,10 @@ describe('token gateway', () => {
         process.env.REACT_APP_HIF_API_URL = 'http://cat.meow/';
         let accessInfoRequest = nock('http://cat.meow')
           .matchHeader('Content-Type', 'application/json')
-          .post('/token/expend', {access_token: 'Cats', project_id: 1})
+          .post('/token/expend', {access_token: 'Cats'})
           .reply(202, {apiKey: 'Dogs', role: 'HE'});
         let gateway = new TokenGateway();
-        let access_info = await gateway.getAccess('Cats', 1);
+        let access_info = await gateway.getAccess('Cats');
         expect(accessInfoRequest.isDone()).toBeTruthy()
       })
 
@@ -35,10 +35,10 @@ describe('token gateway', () => {
         process.env.REACT_APP_HIF_API_URL = 'http://cat.meow/';
         let accessInfoRequest = nock('http://cat.meow')
           .matchHeader('Content-Type', 'application/json')
-          .post('/token/expend', {access_token: 'Cats', project_id: 1})
+          .post('/token/expend', {access_token: 'Cats'})
           .reply(202, {apiKey: 'Dogs'});
         let gateway = new TokenGateway();
-        let access_info = await gateway.getAccess('Cats', 1);
+        let access_info = await gateway.getAccess('Cats');
         expect(access_info.apiKey.apiKey).toEqual('Dogs')
       });
 
@@ -46,10 +46,10 @@ describe('token gateway', () => {
         process.env.REACT_APP_HIF_API_URL = 'http://cat.meow/';
         let accessInfoRequest = nock('http://cat.meow')
           .matchHeader('Content-Type', 'application/json')
-          .post('/token/expend', {access_token: 'Cats', project_id: 1})
+          .post('/token/expend', {access_token: 'Cats'})
           .reply(202, {apiKey: 'Dogs', role: "6"});
         let gateway = new TokenGateway();
-        let access_info = await gateway.getAccess('Cats', 1);
+        let access_info = await gateway.getAccess('Cats');
         expect(access_info.userRole.userRole).toEqual("6")
       })
     });
@@ -59,10 +59,10 @@ describe('token gateway', () => {
         process.env.REACT_APP_HIF_API_URL = 'http://cat.meow/';
         let accessInfoRequest = nock('http://cat.meow')
           .matchHeader('Content-Type', 'application/json')
-          .post('/token/expend', {access_token: 'Cats', project_id: 1})
+          .post('/token/expend', {access_token: 'Cats'})
           .reply(400);
         let gateway = new TokenGateway();
-        let apiKey = await gateway.getAccess('Cats', 1);
+        let apiKey = await gateway.getAccess('Cats');
         expect(apiKey).toEqual(null)
       })
     })
@@ -72,10 +72,10 @@ describe('token gateway', () => {
         process.env.REACT_APP_HIF_API_URL = 'http://cat.meow/';
         let accessInfoRequest = nock('http://cat.meow')
           .matchHeader('Content-Type', 'application/json')
-          .post('/token/expend', {access_token: 'Cats', project_id: 1})
+          .post('/token/expend', {access_token: 'Cats'})
           .reply(403);
         let gateway = new TokenGateway();
-        let apiKey = await gateway.getAccess('Cats', 1);
+        let apiKey = await gateway.getAccess('Cats');
         expect(apiKey).toEqual(null)
       })
     })
@@ -87,10 +87,10 @@ describe('token gateway', () => {
         process.env.REACT_APP_HIF_API_URL = 'http://cat.meow/';
         let accessInfoRequest = nock('http://cat.meow')
           .matchHeader('Content-Type', 'application/json')
-          .post('/token/request', {email_address: 'cats@cathouse.com', project_id: 8})
+          .post('/token/request', {email_address: 'cats@cathouse.com'})
           .reply(200);
         let gateway = new TokenGateway();
-        await gateway.requestToken('cats@cathouse.com', 8);
+        await gateway.requestToken('cats@cathouse.com');
         expect(accessInfoRequest.isDone()).toBeTruthy()
       })
     })
@@ -100,10 +100,10 @@ describe('token gateway', () => {
         process.env.REACT_APP_HIF_API_URL = 'http://cat.meow/';
         let accessInfoRequest = nock('http://cat.meow')
           .matchHeader('Content-Type', 'application/json')
-          .post('/token/expend', {access_token: 'Cats', project_id: 8})
+          .post('/token/expend', {access_token: 'Cats'})
           .reply(202, {apiKey: 'Dogs'});
         let gateway = new TokenGateway();
-        let apiKey = await gateway.getAccess('Cats', 8);
+        let apiKey = await gateway.getAccess('Cats');
         expect(accessInfoRequest.isDone()).toBeTruthy()
       })
 
@@ -111,10 +111,10 @@ describe('token gateway', () => {
         process.env.REACT_APP_HIF_API_URL = 'http://cat.meow/';
         let accessInfoRequest = nock('http://cat.meow')
           .matchHeader('Content-Type', 'application/json')
-          .post('/token/expend', {access_token: 'Cats', project_id: 8})
+          .post('/token/expend', {access_token: 'Cats'})
           .reply(202, {apiKey: 'Dogs'});
         let gateway = new TokenGateway();
-        let access_info = await gateway.getAccess('Cats', 8);
+        let access_info = await gateway.getAccess('Cats');
         expect(access_info.apiKey.apiKey).toEqual('Dogs')
       });
     });
@@ -124,10 +124,10 @@ describe('token gateway', () => {
         process.env.REACT_APP_HIF_API_URL = 'http://cat.meow/';
         let accessInfoRequest = nock('http://cat.meow')
           .matchHeader('Content-Type', 'application/json')
-          .post('/token/expend', {access_token: 'Cats', project_id: 8})
+          .post('/token/expend', {access_token: 'Cats'})
           .reply(400);
         let gateway = new TokenGateway();
-        let apiKey = await gateway.getAccess('Cats', 8);
+        let apiKey = await gateway.getAccess('Cats');
         expect(apiKey).toEqual(null)
       })
     })
@@ -137,10 +137,10 @@ describe('token gateway', () => {
         process.env.REACT_APP_HIF_API_URL = 'http://cat.meow/';
         let accessInfoRequest = nock('http://cat.meow')
           .matchHeader('Content-Type', 'application/json')
-          .post('/token/expend', {access_token: 'Cats', project_id: 8})
+          .post('/token/expend', {access_token: 'Cats'})
           .reply(403);
         let gateway = new TokenGateway();
-        let apiKey = await gateway.getAccess('Cats', 8);
+        let apiKey = await gateway.getAccess('Cats');
         expect(apiKey).toEqual(null)
       })
     })

--- a/src/UseCase/CanAccessMonitor/canAccessMonitor.test.js
+++ b/src/UseCase/CanAccessMonitor/canAccessMonitor.test.js
@@ -1,0 +1,105 @@
+import CanAccessMonitor from ".";
+
+describe("CanAccessMonitor", () => {
+  describe('Given a valid saved api key', () => {
+    describe('example 1', () => {
+      let apiKeyGatewaySpy = { getApiKey: jest.fn(() => ({apiKey: 'apikey'})), setApiKey: jest.fn()};
+      let tokenGatewaySpy = {
+        getAccess: jest.fn(() => ({apiKey: {apiKey: 'Cats'}, userRole: {userRole: '3'}}))
+      };
+      let userRoleGatewaySpy = { getUserRole: jest.fn(()=> ({userRole: '3'})) }
+      let useCase = new CanAccessMonitor(tokenGatewaySpy, apiKeyGatewaySpy, userRoleGatewaySpy);
+      it('calls the api key gateway', async () => {
+        await useCase.execute("");
+        expect(apiKeyGatewaySpy.getApiKey).toHaveBeenCalled();
+        expect(tokenGatewaySpy.getAccess).not.toHaveBeenCalled();
+      });
+
+      it('calls the user role gateway', async () => {
+        await useCase.execute("", 1);
+        expect(userRoleGatewaySpy.getUserRole).toHaveBeenCalled();
+      });
+
+      it('returns the api key and user role', async () => {
+        expect(await useCase.execute("")).toEqual({
+          valid: true,
+          apiKey: 'apikey',
+          userRole: '3'
+        });
+      });
+    });
+    describe('example 2', () => {
+      let apiKeyGatewaySpy = { getApiKey: jest.fn(() => ({apiKey: 'key'})), setApiKey: jest.fn()};
+      let tokenGatewaySpy = {
+        getAccess: jest.fn(() => ({apiKey: {apiKey: 'Cats'}, userRole: {userRole: '5'}}))
+      };
+      let userRoleGatewaySpy = { getUserRole: jest.fn(()=> ({userRole: '5'})) }
+      let useCase = new CanAccessMonitor(tokenGatewaySpy, apiKeyGatewaySpy, userRoleGatewaySpy);
+      it('calls the api key gateway', async () => {
+        await useCase.execute("");
+        expect(apiKeyGatewaySpy.getApiKey).toHaveBeenCalled();
+        expect(tokenGatewaySpy.getAccess).not.toHaveBeenCalled();
+      });
+
+      it('calls the project gateway', async () => {
+        await useCase.execute("");
+        expect(tokenGatewaySpy.getAccess).not.toHaveBeenCalled();
+      });
+
+      it('returns the api key', async () => {
+        expect(await useCase.execute("")).toEqual({valid: true, apiKey: 'key', userRole: '5'});
+      });
+    });
+  });
+
+  describe('Given a valid token', () => {
+    let apiKeyGatewaySpy = { getApiKey: jest.fn(() => ({apiKey: null})), setApiKey: jest.fn()};
+    let userRoleGatewaySpy = { getUserRole: jest.fn(() => ({userRole: 'he'})), setUserRole: jest.fn()}
+    let tokenGatewaySpy = {
+      getAccess: jest.fn(() => ({apiKey: { apiKey: 'Cats'}, userRole: {userRole: 'he'}}))
+    };
+    let useCase = new CanAccessMonitor(tokenGatewaySpy, apiKeyGatewaySpy, userRoleGatewaySpy);
+
+    it('Saves the new api key', async () => {
+      await useCase.execute("");
+      expect(apiKeyGatewaySpy.setApiKey).toBeCalledWith('Cats');
+    });
+
+    it('Saves the user role', async () => {
+      await useCase.execute("");
+      expect(userRoleGatewaySpy.setUserRole).toBeCalledWith('he')
+    })
+
+    it('Calls the token gateway', async () => {
+      await useCase.execute("");
+      expect(tokenGatewaySpy.getAccess).toBeCalledWith("");
+    });
+
+    it('Calls the token gateway with an access token', async () => {
+      await useCase.execute("Cats");
+      expect(tokenGatewaySpy.getAccess).toBeCalledWith("Cats");
+    });
+
+    it('returns the api key', async () => {
+      expect((await useCase.execute("Doggos")).apiKey).toEqual('Cats')
+    });
+
+    it('retuns the role', async () => {
+      expect((await useCase.execute("Doggos")).userRole).toEqual('he')
+    });
+
+  });
+
+  describe('Given an invalid token and no valid saved api key', () => {
+    let tokenGatewaySpy = {
+      getAccess: jest.fn(() => (null))
+    };
+    let apiKeyGatewaySpy = { getApiKey: jest.fn(() => ({apiKey: ''})), setApiKey: jest.fn()};
+    let userRoleGatewaySpy = jest.fn()
+    let useCase = new CanAccessMonitor(tokenGatewaySpy, apiKeyGatewaySpy, userRoleGatewaySpy);
+
+    it('Given empty string as access token it returns false', async () => {
+      expect((await useCase.execute("")).valid).toEqual(false)
+    });
+  });
+});

--- a/src/UseCase/CanAccessMonitor/index.js
+++ b/src/UseCase/CanAccessMonitor/index.js
@@ -1,21 +1,17 @@
 export default class CanAccessProject {
-  constructor(tokenGateway, apiKeyGateway, userRoleGateway, projectGateway) {
+  constructor(tokenGateway, apiKeyGateway, userRoleGateway, ) {
     this.tokenGateway = tokenGateway;
     this.apiKeyGateway = apiKeyGateway;
     this.userRoleGateway = userRoleGateway;
-    this.projectGateway = projectGateway;
   }
 
-  async execute(access_token, project_id) {
-    let project = await this.projectGateway.findById(project_id);
-
-    if (project.success) {
+  async execute(access_token) {
+    if(this.apiKeyGateway.getApiKey().apiKey) {
       return {
         valid: true,
         apiKey: this.apiKeyGateway.getApiKey().apiKey,
         userRole: this.userRoleGateway.getUserRole().userRole
       };
-
     } else {
       let receivedApiKey = await this.tokenGateway.getAccess(access_token);
       if (receivedApiKey === null) {

--- a/src/UseCase/CanAccessProject/canAccessProject.test.js
+++ b/src/UseCase/CanAccessProject/canAccessProject.test.js
@@ -82,12 +82,12 @@ describe("CanAccessProject", () => {
 
     it('Calls the token gateway', async () => {
       await useCase.execute("", 1);
-      expect(tokenGatewaySpy.getAccess).toBeCalledWith("", 1);
+      expect(tokenGatewaySpy.getAccess).toBeCalledWith("");
     });
 
     it('Calls the token gateway with an access token', async () => {
       await useCase.execute("Cats", 3);
-      expect(tokenGatewaySpy.getAccess).toBeCalledWith("Cats", 3);
+      expect(tokenGatewaySpy.getAccess).toBeCalledWith("Cats");
     });
 
     it('returns the api key', async () => {

--- a/src/UseCase/CanAccessProject/index.js
+++ b/src/UseCase/CanAccessProject/index.js
@@ -16,7 +16,7 @@ export default class CanAccessProject {
         userRole: this.userRoleGateway.getUserRole().userRole
       };
     } else {
-      let receivedApiKey = await this.tokenGateway.getAccess(access_token, project_id);
+      let receivedApiKey = await this.tokenGateway.getAccess(access_token);
       if (receivedApiKey === null) {
         return { valid: false }
       } else {

--- a/src/UseCase/RequestToken/index.js
+++ b/src/UseCase/RequestToken/index.js
@@ -3,7 +3,7 @@ export default class RequestToken {
     this.requestTokenGateway = requestTokenGateway
   }
 
-  execute(email_address, project_id, address) {
-    this.requestTokenGateway.requestToken(email_address, project_id, address)
+  execute(email_address, address) {
+    this.requestTokenGateway.requestToken(email_address, address)
   }
 }

--- a/src/UseCase/RequestToken/requestToken.test.js
+++ b/src/UseCase/RequestToken/requestToken.test.js
@@ -7,7 +7,7 @@ describe('requesting a new token', () => {
 
   it('requests a token', async () => {
     let use_case = new RequestToken(tokenGatewaySpy);
-    use_case.execute("cats@cathouse.com", 1, "http://localhost")
-    expect(tokenGatewaySpy.requestToken).toHaveBeenCalledWith("cats@cathouse.com", 1, "http://localhost")
+    use_case.execute("cats@cathouse.com", "http://localhost")
+    expect(tokenGatewaySpy.requestToken).toHaveBeenCalledWith("cats@cathouse.com", "http://localhost")
   })
 });

--- a/test/ApiSimulator/index.js
+++ b/test/ApiSimulator/index.js
@@ -82,9 +82,9 @@ class APISimulator {
   expendEmptyTokenForProject() {
     let request = nock(this.url)
       .matchHeader("Content-Type", "application/json")
-      .post("/token/expend", { });
+      .post("/token/expend", {});
 
-    return new APIResponse(request, { apiKey: "abc" });
+    return new APIResponse(request, { apiKey: "abc", role: "Homes England" });
   }
 
   expendToken(access_token, role = "Homes England") {
@@ -92,7 +92,7 @@ class APISimulator {
       .matchHeader("Content-Type", "application/json")
       .post("/token/expend", { access_token });
 
-    return new APIResponse(request, { apiKey: "abc", role });
+    return new APIResponse(request, { apiKey: "abc", role: "Homes England" });
   }
 }
 

--- a/test/ApiSimulator/index.js
+++ b/test/ApiSimulator/index.js
@@ -79,18 +79,18 @@ class APISimulator {
     return new APIResponse(returnRequest, response);
   }
 
-  expendEmptyTokenForProject(project_id) {
+  expendEmptyTokenForProject() {
     let request = nock(this.url)
       .matchHeader("Content-Type", "application/json")
-      .post("/token/expend", { project_id });
+      .post("/token/expend", { });
 
     return new APIResponse(request, { apiKey: "abc" });
   }
 
-  expendToken(access_token, project_id, role = "Homes England") {
+  expendToken(access_token, role = "Homes England") {
     let request = nock(this.url)
       .matchHeader("Content-Type", "application/json")
-      .post("/token/expend", { access_token, project_id });
+      .post("/token/expend", { access_token });
 
     return new APIResponse(request, { apiKey: "abc", role });
   }


### PR DESCRIPTION
Linked to https://github.com/homes-england/monitor-api/pull/427

This PR doesn't include the the project list yet, it is just to switch round the authentication so it just checks the user and not the user linked to the project.

I've added a page for if they go to a project which aren't a member. Which is an almost copy of the Home Page, this page can be a bit more meaningful when the project list is up and running on the Home Page. 