### PR TITLE
Add button to refresh cookies

### DIFF
--- a/src/Components/ProjectPortal/index.js
+++ b/src/Components/ProjectPortal/index.js
@@ -54,7 +54,7 @@ export default class Portal extends React.Component {
         <div className="col-md-8">
           <h1>Homes England Monitor</h1>
           <p>
-            Welcome to the Homes England monitoring system. You are not a member of this project. If you believe you should have access
+            Welcome to the Homes England monitoring system. If you believe you should have access
             to this project, or have any feedback or queries please feel free to email{" "}
             <a href={"mailto:" + this.env.REACT_APP_SUPPORT_EMAIL}>
               {this.env.REACT_APP_SUPPORT_EMAIL}

--- a/src/Components/ProjectPortal/index.js
+++ b/src/Components/ProjectPortal/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import "../Homepage/style.css";
+import Cookies from 'js-cookie';
 import runtimeEnv from "@mars/heroku-js-runtime-env";
 
 export default class Portal extends React.Component {
@@ -25,6 +26,21 @@ export default class Portal extends React.Component {
     </button>
   }
 
+  refreshCookies = () => {
+    Cookies.remove('apikey');
+    window.location.reload();
+  }
+
+  renderRefreshCookiesButton = () => {
+    return <button
+      data-test="refresh-cookies"
+      className="btn btn-link"
+      onClick={this.refreshCookies}
+    >
+      Refresh Login
+    </button>
+  }
+
   render() {
     if (this.state.apiKey === null) {
       return <div>Loading</div>
@@ -45,6 +61,8 @@ export default class Portal extends React.Component {
             </a>
             .
           </p>
+          <p>If you believe you have already been added to project {this.props.projectId}, you can try refreshing your login: {this.renderRefreshCookiesButton()}</p>
+          
           {this.renderBackToHomepageButton()}
         </div>
         <div className="col-md-2" />

--- a/src/Components/ProjectPortal/projectPortal.test.js
+++ b/src/Components/ProjectPortal/projectPortal.test.js
@@ -31,25 +31,38 @@ describe("ProjectPortal", () => {
     expect(CanAccessProjectSpy.execute).toHaveBeenCalledWith("Cats", 1);
   });
 
-  it("shows a button back to homepage if use case returns false", async () => {
-    CanAccessProjectSpy = {
-      execute: jest.fn(async () => {
-        return {
-          valid: false
-        };
-      })
-    };
-    let wrapper = mount(
-      <ProjectPortal
-        projectId="1"
-        token="Cats"
-        canAccessProject={CanAccessProjectSpy}
-      />
-    );
-    await wait();
-    wrapper.update();
-    expect(wrapper.find('[data-test="back-to-homepage"]').length).toEqual(1);
+  describe("Use Case returns false", () => {
+    let wrapper;
+    beforeEach(() => {
+      CanAccessProjectSpy = {
+        execute: jest.fn(async () => {
+          return {
+            valid: false
+          };
+        })
+      };
+      wrapper = mount(
+        <ProjectPortal
+          projectId="1"
+          token="Cats"
+          canAccessProject={CanAccessProjectSpy}
+        />
+      );
+    });
+
+    it("shows a button back to homepage ", async () => {
+      await wait();
+      wrapper.update();
+      expect(wrapper.find('[data-test="back-to-homepage"]').length).toEqual(1);
+    });
+  
+    it("shows a button to remove cookies", async () => {
+      await wait();
+      wrapper.update();
+      expect(wrapper.find('[data-test="refresh-cookies"]').length).toEqual(1);
+    });
   });
+
 
   it("renders children if the use case returns true", async () => {
     CanAccessProjectSpy = {


### PR DESCRIPTION
WHY: If someone gets added to a project after their api key was set in their cookies then they won't be able to see the project without logging in again. 

Very open to suggestions about rewording the text.