### PR TITLE
Check for disabled prop in date widget

### DIFF
--- a/src/Components/BritishDate/britishDate.test.js
+++ b/src/Components/BritishDate/britishDate.test.js
@@ -216,6 +216,19 @@ describe("<BritishDate>", () => {
         expect(wrapper.find("[data-test='date-year']").props().readOnly).toEqual(true);
       });
 
+      it("When passed the disbaled prop", async () => {
+        let wrapper = mount(<BritishDate
+          value="2007/06/29"
+          onChange={onChangeSpy}
+          disabled={true}
+        />);
+
+        await wrapper.update();
+        expect(wrapper.find("[data-test='date-day']").props().readOnly).toEqual(true);
+        expect(wrapper.find("[data-test='date-month']").props().readOnly).toEqual(true);
+        expect(wrapper.find("[data-test='date-year']").props().readOnly).toEqual(true);
+      });
+
       describe("When disabled with .readonly schema property", () => {
         it("With an empty uiSchema", async () => {
           let wrapper = mount(<BritishDate

--- a/src/Components/BritishDate/index.js
+++ b/src/Components/BritishDate/index.js
@@ -100,6 +100,7 @@ export default class BritishDate extends React.Component {
 
   isInputDisabled = () => {
     if ((this.props.uiSchema && this.props.uiSchema["ui:disabled"])
+      || this.props.disabled
         || (this.props.schema && this.props.schema.readonly)) {
       return true;
     }


### PR DESCRIPTION
The uiSchema wasn't being passed through as a prop so if the date is marked a laReadOnly it's wasn't being picked up by checking for the schema containing a readonly flag.